### PR TITLE
Add copyrights and SPDX identifier headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Copyright 2018 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+
 # Unique GitHub App identifier
 APP_ID=
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# Copyright 2018 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+
 sudo: false
 language: node_js
 node_js:

--- a/bandit.js
+++ b/bandit.js
@@ -1,3 +1,6 @@
+// Copyright 2018 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
 const { spawn } = require('child_process')
 const fs = require('fs')
 const path = require('path')

--- a/cache.js
+++ b/cache.js
@@ -1,3 +1,6 @@
+// Copyright 2018 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
 const fs = require('fs-extra')
 const path = require('path')
 

--- a/config.js
+++ b/config.js
@@ -1,3 +1,6 @@
+// Copyright 2018 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
 const config = {
   cleanupAfterRun: true,
   compareAgainstBaseline: true,

--- a/index.js
+++ b/index.js
@@ -1,3 +1,6 @@
+// Copyright 2018 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
 const runBandit = require('./bandit')
 const generateOutput = require('./report')
 const cache = require('./cache')

--- a/report.js
+++ b/report.js
@@ -1,3 +1,6 @@
+// Copyright 2018 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
 function annotation (issue) {
   const path = issue.filename
   const start_line = issue.line_number

--- a/test/bandit.test.js
+++ b/test/bandit.test.js
@@ -1,3 +1,6 @@
+// Copyright 2018 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
 const runBandit = require('../bandit')
 
 describe('Bandit runner', () => {

--- a/test/fixtures/python/cgi.py
+++ b/test/fixtures/python/cgi.py
@@ -1,3 +1,6 @@
+# Copyright 2018 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+
 import requests
 import wsgiref.handlers
 

--- a/test/fixtures/python/https.py
+++ b/test/fixtures/python/https.py
@@ -1,3 +1,6 @@
+# Copyright 2018 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+
 import httplib
 c = httplib.HTTPSConnection("example.com")
 

--- a/test/fixtures/python/key_sizes.old.py
+++ b/test/fixtures/python/key_sizes.old.py
@@ -1,3 +1,6 @@
+# Copyright 2018 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+
 from cryptography.hazmat import backends
 from cryptography.hazmat.primitives.asymmetric import dsa
 from cryptography.hazmat.primitives.asymmetric import rsa

--- a/test/fixtures/python/key_sizes.py
+++ b/test/fixtures/python/key_sizes.py
@@ -1,3 +1,6 @@
+# Copyright 2018 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+
 from cryptography.hazmat import backends
 from cryptography.hazmat.primitives.asymmetric import dsa
 from cryptography.hazmat.primitives.asymmetric import rsa

--- a/test/fixtures/python/mix.py
+++ b/test/fixtures/python/mix.py
@@ -1,3 +1,6 @@
+# Copyright 2018 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+
 import ssl
 from cryptography.hazmat import backends
 from cryptography.hazmat.primitives.asymmetric import dsa

--- a/test/fixtures/python/twisted_dir.py
+++ b/test/fixtures/python/twisted_dir.py
@@ -1,3 +1,6 @@
+# Copyright 2018 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+
 from twisted.internet import reactor
 from twisted.web import static, server, twcgi
 

--- a/test/fixtures/python/twisted_script.py
+++ b/test/fixtures/python/twisted_script.py
@@ -1,3 +1,6 @@
+# Copyright 2018 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+
 from twisted.internet import reactor
 from twisted.web import static, server, twcgi
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,3 +1,6 @@
+// Copyright 2018 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
 const fs = require('fs-extra')
 
 const { Application } = require('probot')

--- a/test/report.test.js
+++ b/test/report.test.js
@@ -1,3 +1,6 @@
+// Copyright 2018 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
 const generateReport = require('../report')
 
 const banditResults = require('./fixtures/reports/mix_results.json')


### PR DESCRIPTION
Each file needs to have a copyright and license header. The
license uses the SPDX shorthand identifier.

Signed-off-by: Eric Brown <browne@vmware.com>