### PR TITLE
Fix test failures caused by fixture copyrights

### DIFF
--- a/test/fixtures/python/cgi.py
+++ b/test/fixtures/python/cgi.py
@@ -1,6 +1,3 @@
-# Copyright 2018 VMware, Inc.
-# SPDX-License-Identifier: BSD-2-Clause
-
 import requests
 import wsgiref.handlers
 

--- a/test/fixtures/python/https.py
+++ b/test/fixtures/python/https.py
@@ -1,6 +1,3 @@
-# Copyright 2018 VMware, Inc.
-# SPDX-License-Identifier: BSD-2-Clause
-
 import httplib
 c = httplib.HTTPSConnection("example.com")
 

--- a/test/fixtures/python/key_sizes.old.py
+++ b/test/fixtures/python/key_sizes.old.py
@@ -1,6 +1,3 @@
-# Copyright 2018 VMware, Inc.
-# SPDX-License-Identifier: BSD-2-Clause
-
 from cryptography.hazmat import backends
 from cryptography.hazmat.primitives.asymmetric import dsa
 from cryptography.hazmat.primitives.asymmetric import rsa

--- a/test/fixtures/python/key_sizes.py
+++ b/test/fixtures/python/key_sizes.py
@@ -1,6 +1,3 @@
-# Copyright 2018 VMware, Inc.
-# SPDX-License-Identifier: BSD-2-Clause
-
 from cryptography.hazmat import backends
 from cryptography.hazmat.primitives.asymmetric import dsa
 from cryptography.hazmat.primitives.asymmetric import rsa

--- a/test/fixtures/python/mix.py
+++ b/test/fixtures/python/mix.py
@@ -1,6 +1,3 @@
-# Copyright 2018 VMware, Inc.
-# SPDX-License-Identifier: BSD-2-Clause
-
 import ssl
 from cryptography.hazmat import backends
 from cryptography.hazmat.primitives.asymmetric import dsa

--- a/test/fixtures/python/twisted_dir.py
+++ b/test/fixtures/python/twisted_dir.py
@@ -1,6 +1,3 @@
-# Copyright 2018 VMware, Inc.
-# SPDX-License-Identifier: BSD-2-Clause
-
 from twisted.internet import reactor
 from twisted.web import static, server, twcgi
 

--- a/test/fixtures/python/twisted_script.py
+++ b/test/fixtures/python/twisted_script.py
@@ -1,6 +1,3 @@
-# Copyright 2018 VMware, Inc.
-# SPDX-License-Identifier: BSD-2-Clause
-
 from twisted.internet import reactor
 from twisted.web import static, server, twcgi
 


### PR DESCRIPTION
A recent commit to add copyrights in the bandit test fixtures
caused the tests to fail. Since multiple copyrights could be
added to the test fixtures potentially in the future, it would
be best to exclude from test fixtures so as to not break tests.

Signed-off-by: Eric Brown <browne@vmware.com>