### PR TITLE
Change logging level during tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "scripts": {
     "dev": "nodemon --exec \"npm start\"",
     "start": "probot run ./index.js",
-    "test": "jest && standard",
-    "test:watch": "jest --watch --notify --notifyMode=change --coverage",
+    "test": "LOG_LEVEL=fatal jest && standard",
+    "test:watch": "LOG_LEVEL=fatal jest --watch --notify --notifyMode=change --coverage",
     "lint": "standard --fix"
   },
   "dependencies": {


### PR DESCRIPTION
This makes the output more readable, unfortunately there doesn't seem to be an easy way to disable logging globally.

Closes #24 

Signed-off-by: Antoine Salon <asalon@vmware.com>