### PR TITLE
Small refactoring change plus a test change

### DIFF
--- a/test/bandit.test.js
+++ b/test/bandit.test.js
@@ -1,5 +1,6 @@
 // Copyright 2018 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
+
 const fs = require('fs-extra')
 
 const runBandit = require('../bandit/bandit')
@@ -23,7 +24,7 @@ describe('Bandit runner', () => {
     expect(results).toBeNull()
   })
 
-  afterAll(() => {
+  afterEach(() => {
     fs.remove('test/fixtures/bandit.json')
   })
 })


### PR DESCRIPTION
I think it will be better if we delete the bandit.json file after each test in bandit.runner because that way if a test fails when spawning bandit it will throw "errno file not found" exception and you will know the problem is in the spawning of Bandit. 
If we delete bandit.json file after all tests there is a possibility the spawn of bandit fails but we still read from the existing bandit.json file and get a false-positive.

Also I add a new line where it was needed.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>