### PR TITLE
Fix for bandit annotation problem

### DIFF
--- a/bandit/bandit_annotations.js
+++ b/bandit/bandit_annotations.js
@@ -12,7 +12,7 @@ function getAnnotation (issue) {
   const path = issue.filename
   const startLine = issue.line_number
   const endLine = issue.line_number
-  const annotationLevel = getAnnotationLevel(issue.severity, issue.confidence)
+  const annotationLevel = getAnnotationLevel(issue.issue_severity, issue.issue_confidence)
   const title = `${issue.test_id}:${issue.test_name}`
   const message = issue.issue_text
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -79,7 +79,7 @@ describe('Bandit-linter', () => {
       expect(github.checks.update).toHaveBeenCalledWith(expect.objectContaining({
         check_run_id: 1,
         status: 'completed',
-        conclusion: 'neutral',
+        conclusion: 'failure',
         owner: 'owner_login',
         repo: 'repo_name',
         completed_at: expect.any(String)


### PR DESCRIPTION
There is a bug when accessing the severity and confidence levels on issues found by Bandit.

Here is how a Bandit issue is structured in json: 
![image](https://user-images.githubusercontent.com/16246778/49245280-89060400-f41a-11e8-83e5-80cfe1032ff8.png)
Before I was't accessing the severity and confidence level with the right name.

Also I had to change the conclusion of a test in test/index.test.js because it was wrong. On this test there are three issues with annotation levels 'failure' so the test should fail too.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>