### PR TITLE
Integrate gosec into the app

### DIFF
--- a/bandit/bandit_report.js
+++ b/bandit/bandit_report.js
@@ -26,13 +26,7 @@ module.exports = (results) => {
 
   if (results && results.results.length !== 0) {
     title = config.issuesFoundResultTitle
-    let severityInfo = customSummary(results.metrics._totals)
-    // Temporary output before the final pull request which will combine the
-    // the output for Gosec and Bandit is merged into master
-    summary = 'SEVERITY_HIGH: ' + severityInfo.SEVERITY_HIGH + '\n'
-    summary += 'SEVERITY_MEDIUM: ' + severityInfo.SEVERITY_MEDIUM + '\n'
-    summary += 'SEVERITY_LOW: ' + severityInfo.SEVERITY_LOW + '\n'
-
+    summary = customSummary(results.metrics._totals)
     annotations = results.results.map(issue => getAnnotation(issue))
   } else {
     title = config.noIssuesResultTitle

--- a/cache.js
+++ b/cache.js
@@ -8,9 +8,16 @@ const path = require('path')
  * Get the cache path for this PR branch tag
  * @param {number} prID pull request identifier
  * @param {string} branchTag branch name
+ * @param {string} app Optional: an app that calls the function. (default bandit)
+ * It's needed because gosec uses GOPATH.
  */
-function getBranchPath (prID, branchTag) {
-  return path.join('cache', prID.toString(), branchTag)
+function getBranchPath (prID, branchTag, app) {
+  app = app || 'bandit'
+  if (app === 'bandit') {
+    return path.join('cache', prID.toString(), branchTag)
+  } else if (app === 'gosec') {
+    return path.join('cache/go/src', prID.toString())
+  }
 }
 
 /**
@@ -28,9 +35,16 @@ function branchPathExists (prID, branchTag) {
  * @param {string} branchTag a tag to identify the current file revision
  * @param {string} filePath relative file path
  * @param {any} data file data
+ * @param {string} fileType Optional: file type so it knows where to save the file (default python)
+ * It's needed because go files should be in the GOPATH.
  */
-function saveFileToPRCache (prID, branchTag, filePath, data) {
-  writeFileCreateDirs(path.join('cache', prID.toString(), branchTag, filePath), data)
+function saveFileToPRCache (prID, branchTag, filePath, data, fileType) {
+  fileType = fileType || 'python'
+  if (fileType === 'go') {
+    writeFileCreateDirs(path.join('cache/go/src', prID.toString(), filePath), data)
+  } else if (fileType === 'python') {
+    writeFileCreateDirs(path.join('cache', prID.toString(), branchTag, filePath), data)
+  }
 }
 
 /**
@@ -39,6 +53,7 @@ function saveFileToPRCache (prID, branchTag, filePath, data) {
  */
 function clearPRCache (prID) {
   fs.removeSync(path.join('cache', prID.toString()))
+  fs.removeSync(path.join('cache/go/src', prID.toString()))
 }
 
 /**

--- a/gosec/gosec.js
+++ b/gosec/gosec.js
@@ -17,18 +17,19 @@ module.exports = (directory, inputFiles, reportFile) => {
   if (goFiles.length === 0) {
     return null
   }
-
   reportFile = reportFile || 'gosec.json'
-  const reportPath = path.join(directory, reportFile)
+  const reportPath = path.join(__dirname, '../', directory, reportFile)
+
   /**
   * @argument gosec command which the child process will execute
   * @argument -fmt output format of the command
   * @argument out flag which redirects the gosec output to a file
   * @argument reportPath the file where the output of gosec will be stored
+  * @argument goFiles files which will be analyzed by gosec
   */
   let gosecArgs = ['-fmt=json', '-out', reportPath, goFiles]
 
-  let gosecProcess = spawn('gosec', gosecArgs)
+  let gosecProcess = spawn('gosec', gosecArgs, { cwd: path.join(__dirname, '../', directory) })
 
   return new Promise((resolve, reject) => {
     gosecProcess

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "standard": "^12.0.1"
   },
   "engines": {
-    "node": ">= 11.3.0"
+    "node": ">= 8.10"
   },
   "jest": {
     "testEnvironment": "node",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "standard": "^12.0.1"
   },
   "engines": {
-    "node": ">= 8.3"
+    "node": ">= 11.3.0"
   },
   "jest": {
     "testEnvironment": "node",

--- a/test/gosec.spawn.test.js
+++ b/test/gosec.spawn.test.js
@@ -11,21 +11,19 @@ describe('Spawn gosec tests', () => {
   })
 
   test('Run gosec on non go files', async () => {
-    const gosecResult = await gosec('test/fixtures/go/src', ['test/fixtures/go/src/non_go_files/hello_world.py'])
+    const gosecResult = await gosec('test/fixtures/go/src/non_go_files', ['hello_world.py'])
     expect(gosecResult).toBeFalsy()
   })
 
   test('Run gosec on a go file without security problems', async () => {
-    const gosecResult = await gosec('test/fixtures/go/src', ['test/fixtures/go/src/secure_go_files/hello_world.go'])
+    const gosecResult = await gosec('test/fixtures/go/src/secure_go_files', ['hello_world.go'])
     expect(gosecResult.Issues.length).toEqual(0)
+    fs.remove('test/fixtures/go/src/secure_go_files/gosec.json')
   })
 
   test('Run gosec on go problematic file', async () => {
-    const gosecResult = await gosec('test/fixtures/go/src', ['test/fixtures/go/src/bad_files/bad_test_file.go'])
+    const gosecResult = await gosec('test/fixtures/go/src/bad_files', ['bad_test_file.go'])
     expect(gosecResult.Stats.found).toBeGreaterThan(0)
-  })
-
-  afterEach(() => {
-    fs.remove('test/fixtures/go/src/gosec.json')
+    fs.remove('test/fixtures/go/src/bad_files/gosec.json')
   })
 })


### PR DESCRIPTION
Because we depend on the GOPATH enviormental variable and it's conditions I created a /go/src folders in cache folder and because I wanted to use the functions in cache.js I had to change almost all functions in cache.js to behave differently based on which app is calling them (Gosec or Bandit).

Also I added the lines in index.js in which we call Gosec, convert the output from Gosec and merge the outputs from Bandit and Gosec into one. Also I changed a few things about how we save the files initially.

I added the cwd (current working directory) flag when spawning gosec in gosec/gosec.js. This helped me to fix bugs when calling gosec and because of this I had to change where is the file I am removing in the test/gosec.spawn.test.js file.

And in the end I changed the format of the bandit summary so it will be easier to merge the outputs of Bandit and Gosec.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>