### PR TITLE
Changes in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,24 @@
 # Copyright 2018 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 
-sudo: false
+dist: "trusty"
+
+install:
+  - yarn install
+  - pip3 install --user -r requirements.txt
+  - curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $GOPATH/bin 1.2.0
+  - export GOPATH=$GOPATH:/home/travis/build/vmware/precaution/test/fixtures/go
 language: node_js
 node_js:
-  - "8.3"
+  - "8"
+  - "10"
+  - "11"
+
+addons:
+  apt:
+    packages:
+      - "python3"
+      - "python3-pip"
+
 notifications:
   disabled: true


### PR DESCRIPTION
We need to change the Travis CI config file - .travis.yml in order to run tests on travis correctly.
This update correctly configures node versions for travis and installs bandit and gosec.
We use Node versions 8, 10 and 11 (all suported versions according to eslint) because that way we are sure our app works on all supported versions.

Antoine Salon's (@evqna) pull request https://github.com/vmware/precaution/pull/50 helped me a lot to finish this pull request.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>