### PR TITLE
Travis updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,22 @@
 # Copyright 2018 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 
-sudo: false
+dist: "trusty"
+install:
+  - yarn install
+  - pip3 install --user -r requirements.txt
+
 language: node_js
 node_js:
   - "8"
   - "10"
   - "11"
+
+addons:
+  apt:
+    packages:
+      - "python3"
+      - "python3-pip"
 
 notifications:
   disabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@
 sudo: false
 language: node_js
 node_js:
-  - "8.3"
+  - "8"
+  - "10"
+  - "11"
+
 notifications:
   disabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 dist: "trusty"
+
 install:
   - yarn install
   - pip3 install --user -r requirements.txt
+  - curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $GOPATH/bin 1.2.0
 
 language: node_js
 node_js:


### PR DESCRIPTION
This update correctly configures node versions for travis and installs bandit and gosec.

All bandit tests pass but gosec ones are still failing, probably due to some gopath issues.