### PR TITLE
Add a Build Status badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Precaution
 
+[![Build Status](https://travis-ci.com/vmware/precaution.svg?branch=master)](https://travis-ci.com/vmware/precaution)
 [![License](https://img.shields.io/badge/License-BSD%202--Clause-orange.svg)](https://github.com/vmware/precaution/blob/master/LICENSE.txt)
 [![Slack](https://img.shields.io/badge/slack-join%20chat%20%E2%86%92-e01563.svg)](https://code.vmware.com/web/code/join)
 


### PR DESCRIPTION
Like so many other projects, it's useful to have a badge and link
to the current build status to denote the stability of the master
branch.

Signed-off-by: Eric Brown <browne@vmware.com>