### PR TITLE
Fix how we call gosec.js

### DIFF
--- a/gosec/gosec.js
+++ b/gosec/gosec.js
@@ -17,24 +17,24 @@ module.exports = (directory, inputFiles, reportFile) => {
   if (goFiles.length === 0) {
     return null
   }
-
   reportFile = reportFile || 'gosec.json'
-  const reportPath = path.join(directory, reportFile)
+  const currentDirectory = path.join(__dirname, '../', directory)
   /**
   * @argument gosec command which the child process will execute
   * @argument -fmt output format of the command
   * @argument out flag which redirects the gosec output to a file
-  * @argument reportPath the file where the output of gosec will be stored
+  * @argument reportFile the file where the output of gosec will be stored
+  * @argument goFiles files which will be analyzed by gosec
   */
-  let gosecArgs = ['-fmt=json', '-out', reportPath, goFiles]
+  let gosecArgs = ['-fmt=json', '-out', reportFile, goFiles]
 
-  let gosecProcess = spawn('gosec', gosecArgs)
+  let gosecProcess = spawn('gosec', gosecArgs, { cwd: currentDirectory })
 
   return new Promise((resolve, reject) => {
     gosecProcess
       .on('error', reject)
       .on('close', () => {
-        parse.readFile(reportPath, resolve, reject)
+        parse.readFile(path.join(currentDirectory, reportFile), resolve, reject)
       })
   })
 }

--- a/test/gosec.spawn.test.js
+++ b/test/gosec.spawn.test.js
@@ -11,21 +11,19 @@ describe('Spawn gosec tests', () => {
   })
 
   test('Run gosec on non go files', async () => {
-    const gosecResult = await gosec('test/fixtures/go/src', ['test/fixtures/go/src/non_go_files/hello_world.py'])
+    const gosecResult = await gosec('test/fixtures/go/src/non_go_files', ['hello_world.py'])
     expect(gosecResult).toBeFalsy()
   })
 
   test('Run gosec on a go file without security problems', async () => {
-    const gosecResult = await gosec('test/fixtures/go/src', ['test/fixtures/go/src/secure_go_files/hello_world.go'])
+    const gosecResult = await gosec('test/fixtures/go/src/secure_go_files', ['hello_world.go'])
     expect(gosecResult.Issues.length).toEqual(0)
+    fs.remove('test/fixtures/go/src/secure_go_files/gosec.json')
   })
 
   test('Run gosec on go problematic file', async () => {
-    const gosecResult = await gosec('test/fixtures/go/src', ['test/fixtures/go/src/bad_files/bad_test_file.go'])
+    const gosecResult = await gosec('test/fixtures/go/src/bad_files', ['bad_test_file.go'])
     expect(gosecResult.Stats.found).toBeGreaterThan(0)
-  })
-
-  afterEach(() => {
-    fs.remove('test/fixtures/go/src/gosec.json')
+    fs.remove('test/fixtures/go/src/bad_files/gosec.json')
   })
 })


### PR DESCRIPTION
It will be better if the input files for analyze are given by relative directory to the "directory" argument in the gosec.js file.

This is a small pr which prepares for the integration of Gosec pr.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>