### PR TITLE
Use different cache subfolders per repo

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -6,39 +6,43 @@ const path = require('path')
 
 /**
  * Get the cache path for this PR branch tag
+ * @param {number} repoID repository identifier
  * @param {number} prID pull request identifier
  * @param {string} branchTag branch name
  */
-function getBranchPath (prID, branchTag) {
-  return path.join('cache', prID.toString(), branchTag)
+function getBranchPath (repoID, prID, branchTag) {
+  return path.join('cache', repoID.toString(), prID.toString(), branchTag)
 }
 
 /**
  * Check whether the cache directory for this branch exists
+ * @param {number} repoID repository identifier
  * @param {number} prID pull request identifier
  * @param {string} branchTag branch name
  */
-function branchPathExists (prID, branchTag) {
-  return fs.existsSync(getBranchPath(prID, branchTag))
+function branchPathExists (repoID, prID, branchTag) {
+  return fs.existsSync(getBranchPath(repoID, prID, branchTag))
 }
 
 /**
  * Save a file to local PR cache, distinguish by revision
+ * @param {number} repoID unique repository identifier
  * @param {number} prID unique pull request identifier
  * @param {string} branchTag a tag to identify the current file revision
  * @param {string} filePath relative file path
  * @param {any} data file data
  */
-function saveFileToPRCache (prID, branchTag, filePath, data) {
-  writeFileCreateDirs(path.join('cache', prID.toString(), branchTag, filePath), data)
+function saveFileToPRCache (repoID, prID, branchTag, filePath, data) {
+  writeFileCreateDirs(path.join('cache', repoID.toString(), prID.toString(), branchTag, filePath), data)
 }
 
 /**
  * Delete pr cache folder
+ * @param {number} repoID repository identifier
  * @param {number} prID pull request identifier
  */
-function clearPRCache (prID) {
-  fs.removeSync(path.join('cache', prID.toString()))
+function clearPRCache (repoID, prID) {
+  fs.removeSync(path.join('cache', repoID.toString(), prID.toString()))
 }
 
 /**

--- a/test/events/check_suite.rerequested.json
+++ b/test/events/check_suite.rerequested.json
@@ -29,6 +29,7 @@
       }
     },
     "repository": {
+      "id": 54321,
       "name": "repo_name",
       "full_name": "owner_login/repo_name",
       "owner": {

--- a/test/events/pull_request.opened.json
+++ b/test/events/pull_request.opened.json
@@ -19,6 +19,7 @@
       }
     },
     "repository": {
+      "id": 12345,
       "name": "repo_name",
       "full_name": "owner_login/repo_name",
       "owner": {


### PR DESCRIPTION
Since pull request numbers are only unique per repository there might be name conflicts when multiple requests are processed simultaneously.

Signed-off-by: Antoine Salon <asalon@vmware.com>