### PR TITLE
Integrate gosec into the app

### DIFF
--- a/bandit/bandit_report.js
+++ b/bandit/bandit_report.js
@@ -26,13 +26,7 @@ module.exports = (results) => {
 
   if (results && results.results.length !== 0) {
     title = config.issuesFoundResultTitle
-    let severityInfo = customSummary(results.metrics._totals)
-    // Temporary output before the final pull request which will combine the
-    // the output for Gosec and Bandit is merged into master
-    summary = 'SEVERITY_HIGH: ' + severityInfo.SEVERITY_HIGH + '\n'
-    summary += 'SEVERITY_MEDIUM: ' + severityInfo.SEVERITY_MEDIUM + '\n'
-    summary += 'SEVERITY_LOW: ' + severityInfo.SEVERITY_LOW + '\n'
-
+    summary = customSummary(results.metrics._totals)
     annotations = results.results.map(issue => getAnnotation(issue))
   } else {
     title = config.noIssuesResultTitle


### PR DESCRIPTION
Because we depend on the GOPATH enviormental variable and it's conditions I created a /go/src folders in cache folder and because I wanted to use the functions in cache.js I had to change almost all functions in cache.js to behave differently based on which app is calling them (Gosec or Bandit).

Also I added the lines in index.js in which we call Gosec, convert the output from Gosec and merge the outputs from Bandit and Gosec into one. Also I changed a few things about how we save the files initially.

I added the cwd (current working directory) flag when spawning gosec in gosec/gosec.js. This helped me to fix bugs when calling gosec and because of this I had to change where is the file I am removing in the test/gosec.spawn.test.js file.

And in the end I changed the format of the bandit summary so it will be easier to merge the outputs of Bandit and Gosec.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>