### PR TITLE
Fix the problem to use Git on Heroku

### DIFF
--- a/.profile
+++ b/.profile
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -x
+
+mkdir $HOME/bin
+
+curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $HOME/bin 1.2.0
+
+
+FILE=".env"
+
+/bin/cat <<EOM >$FILE
+APP_ID=${APP_ID}
+WEBHOOK_SECRET=${WEBHOOK_SECRET}
+LOG_LEVEL=${LOG_LEVEL}
+PRIVATE_KEY=${PRIVATE_KEY}
+WEBHOOK_PROXY_URL=${WEBHOOK_PROXY_URL}
+EOM

--- a/.profile
+++ b/.profile
@@ -4,14 +4,3 @@ set -x
 mkdir $HOME/bin
 
 curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $HOME/bin 1.2.0
-
-
-FILE=".env"
-
-/bin/cat <<EOM >$FILE
-APP_ID=${APP_ID}
-WEBHOOK_SECRET=${WEBHOOK_SECRET}
-LOG_LEVEL=${LOG_LEVEL}
-PRIVATE_KEY=${PRIVATE_KEY}
-WEBHOOK_PROXY_URL=${WEBHOOK_PROXY_URL}
-EOM


### PR DESCRIPTION
I added a .profile file. In an articale from Heroku they explain what is the procfile used for:

"During startup, the container starts a bash shell that runs any code in $HOME/.profile before executing the dyno’s command."
From: https://devcenter.heroku.com/articles/dynos#startup 

First I create a bin folder (I can't upload it because it's in the .gitignore file) then I added two commands which are installing gosec.

Also I added a few lines in which I create an .env file necessary for probot. I fill this file with the enviormental variables needed by probot, those  environmental variables are on Heroku I and get them from there.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>