### PR TITLE
Fix a bug when call gosec with more than one go file

### DIFF
--- a/gosec/gosec.js
+++ b/gosec/gosec.js
@@ -19,6 +19,7 @@ module.exports = (directory, inputFiles, reportFile) => {
   }
   reportFile = reportFile || 'gosec.json'
   const currentDirectory = path.join(__dirname, '../', directory)
+
   /**
   * @argument gosec command which the child process will execute
   * @argument -fmt output format of the command
@@ -26,7 +27,8 @@ module.exports = (directory, inputFiles, reportFile) => {
   * @argument reportFile the file where the output of gosec will be stored
   * @argument goFiles files which will be analyzed by gosec
   */
-  let gosecArgs = ['-fmt=json', '-out', reportFile, goFiles]
+  let args = ['-fmt=json', '-out', reportFile]
+  let gosecArgs = args.concat(goFiles)
 
   let gosecProcess = spawn('gosec', gosecArgs, { cwd: currentDirectory })
 

--- a/gosec/gosec.js
+++ b/gosec/gosec.js
@@ -27,8 +27,7 @@ module.exports = (directory, inputFiles, reportFile) => {
   * @argument reportFile the file where the output of gosec will be stored
   * @argument goFiles files which will be analyzed by gosec
   */
-  let args = ['-fmt=json', '-out', reportFile]
-  let gosecArgs = args.concat(goFiles)
+  let gosecArgs = ['-fmt=json', '-out', reportFile, ...goFiles]
 
   let gosecProcess = spawn('gosec', gosecArgs, { cwd: currentDirectory })
 

--- a/test/fixtures/go/src/multiple_bad_files/bad_test_file.go
+++ b/test/fixtures/go/src/multiple_bad_files/bad_test_file.go
@@ -1,0 +1,29 @@
+package main
+
+import "fmt"
+
+import (
+	"log"
+	"net"
+	"os"
+)
+
+func main() {
+
+	// Harcoded credentials
+	username := "admin"
+	password := "f62e5bcda4fae4f82370da0c6f20697b8f8447ef"
+	fmt.Println("Doing something with: ", username, password)
+
+	// SampleCodeG102 code snippet for network binding
+	l, err := net.Listen("tcp", "0.0.0.0:2000")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer l.Close()
+
+	// Changing file permissions of important files
+	os.Chmod("/etc/passwd", 0777)
+	os.Chmod("~/.bashrc", 0777)
+
+}

--- a/test/fixtures/go/src/multiple_bad_files/networking_binding_test.go
+++ b/test/fixtures/go/src/multiple_bad_files/networking_binding_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"log"
+	"net"
+)
+
+func networkBind() {
+	l, err := net.Listen("tcp", "0.0.0.0:2000")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer l.Close()
+}
+
+func main() {
+
+}

--- a/test/fixtures/go/src/multiple_bad_files/randNumTest.go
+++ b/test/fixtures/go/src/multiple_bad_files/randNumTest.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"crypto/rand"
+)
+
+func hi() {
+
+}
+
+func test() (int, error) {
+	return 0, nil
+}
+
+func randNum() {
+	good, _ := rand.Read(nil)
+	println(good)
+
+}
+func main() {
+
+}
+
+// SampleCodeG404 - weak random number
+
+// v, _ := test()
+// fmt.Println(v)

--- a/test/gosec.spawn.test.js
+++ b/test/gosec.spawn.test.js
@@ -26,4 +26,10 @@ describe('Spawn gosec tests', () => {
     expect(gosecResult.Stats.found).toBeGreaterThan(0)
     fs.remove('test/fixtures/go/src/bad_files/gosec.json')
   })
+
+  test('Run gosec multiple go files', async () => {
+    const gosecResult = await gosec('test/fixtures/go/src/multiple_bad_files/', ['bad_test_file.go', 'networking_binding_test.go', 'randNumTest.go'])
+    expect(gosecResult.Stats.found).toBeGreaterThan(0)
+    fs.remove('test/fixtures/go/src/multiple_bad_files/gosec.json')
+  })
 })


### PR DESCRIPTION
There is a bug when we call gosec with multiple go files.

The reason I belive is that in the gosecArgs array when I give another array - goFiles as argument javascirpt somehow flattens the goFiles array and Gosec recives something strange as argument.

The reason I belive this is that when I concatenate the args array with the gofile array now it works with pull requests with multiple go files.

I added a test for this case.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>