### PR TITLE
Use logs for Gosec

### DIFF
--- a/gosec/gosec.js
+++ b/gosec/gosec.js
@@ -4,6 +4,7 @@
 const { spawn } = require('child_process')
 const parse = require('../parse_output.js')
 const path = require('path')
+const fs = require('fs')
 
 /**
  * Spawn a gosec process analyzing all the files in a given directory.
@@ -30,10 +31,19 @@ module.exports = (directory, inputFiles, reportFile) => {
 
   let gosecProcess = spawn('gosec', gosecArgs, { cwd: currentDirectory })
 
+  let logs = ''
+  gosecProcess.stderr.on('data', function (data) {
+    logs += data.toString()
+  })
+
   return new Promise((resolve, reject) => {
     gosecProcess
       .on('error', reject)
       .on('close', () => {
+        if (!fs.existsSync(path.join(currentDirectory, reportFile))) {
+          console.log('The logs for Gosec are: ')
+          console.log(logs)
+        }
         parse.readFile(path.join(currentDirectory, reportFile), resolve, reject)
       })
   })


### PR DESCRIPTION
I noticed that many times we have problems with Gosec the only information we have is this:

"ERROR event: ENONET: no such file or directory <the file> in the parse output file!"

This happens because Gosec failed to run correctly but we don't know the reason.

It's much more useful to console log the logs from the Gosec call.

Here is an example of the logs which are showed:

![image](https://user-images.githubusercontent.com/16246778/49797436-1d8c3280-fd48-11e8-9684-fa2af7c7568d.png)

This example is from this pull request:
https://github.com/MVrachev/Travic-CI---Tests/pull/685

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>