### PR TITLE
Relative file paths in Gosec issues

### DIFF
--- a/gosec/gosec.js
+++ b/gosec/gosec.js
@@ -19,7 +19,7 @@ module.exports = (directory, inputFiles, reportFile) => {
     return null
   }
   reportFile = reportFile || 'gosec.json'
-  const currentDirectory = path.join(__dirname, '../', directory)
+  const currentDirectory = path.resolve(directory)
   /**
   * @argument gosec command which the child process will execute
   * @argument -fmt output format of the command

--- a/gosec/gosec_annotations.js
+++ b/gosec/gosec_annotations.js
@@ -5,11 +5,12 @@ const { getAnnotationLevel } = require('../annotations_levels')
 
 /**
  * @param {*} issue - an issue from which the annotation will be build
+ * @param {String} directory working directory for the Gosec process
  * @return {Object} returns an annotation object as specified here:
  * https://developer.github.com/v3/checks/runs/#annotations-object
  */
-function getAnnotation (issue) {
-  const path = issue.file
+function getAnnotation (issue, directory) {
+  const path = issue.file.replace(directory + '/', '')
   const startLine = issue.line
   const endLine = issue.line
   const annotationLevel = getAnnotationLevel(issue.severity, issue.confidence)

--- a/gosec/gosec_report.js
+++ b/gosec/gosec_report.js
@@ -26,16 +26,16 @@ function customSummary (gosecAnnotations) {
 }
 
 /**
- * Convert gosec json output into valid 'output' object for check run conclusion
- * @param {any} results gosec json output
+ *
+ * @param {*} results results gosec json output
+ * @param {*} directory working directory for Gosec process
  */
-module.exports = (results) => {
+module.exports = (results, directory) => {
   let title, summary, annotations
-
   if (results && results.Issues.length !== 0) {
     title = config.issuesFoundResultTitle
     summary = customSummary(results.Issues)
-    annotations = results.Issues.map(issue => getAnnotation(issue))
+    annotations = results.Issues.map(issue => getAnnotation(issue, directory))
   } else {
     title = config.noIssuesResultTitle
     summary = config.noIssuesResultSummary

--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ const cache = require('./cache')
 const { config } = require('./config')
 const apiHelper = require('./github_api_helper')
 
+const path = require('path')
+
 /**
  * @param {import('probot').Application} app - Probot's Application class.
  */
@@ -81,7 +83,7 @@ async function runLinterFromPRData (pullRequests, context, headSha) {
     const banditReport = generateBanditReport(banditResults, cache.getBranchPath(repoID, PR.id, 'head', 'bandit'))
 
     const gosecResults = await runGosec(cache.getBranchPath(repoID, PR.id, 'head', 'gosec'), inputFiles)
-    const gosecReport = generateGosecReport(gosecResults)
+    const gosecReport = generateGosecReport(gosecResults, path.join(__dirname, cache.getBranchPath(repoID, PR.id, 'head', 'gosec')))
 
     const output = mergeReports(banditReport, gosecReport)
     const resolvedCheckRunResponse = await checkRunResponse

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ async function runLinterFromPRData (pullRequests, context, headSha) {
     const banditReport = generateBanditReport(banditResults, cache.getBranchPath(repoID, PR.id, 'head', 'bandit'))
 
     const gosecResults = await runGosec(cache.getBranchPath(repoID, PR.id, 'head', 'gosec'), inputFiles)
-    const gosecReport = generateGosecReport(gosecResults, path.join(__dirname, cache.getBranchPath(repoID, PR.id, 'head', 'gosec')))
+    const gosecReport = generateGosecReport(gosecResults, path.resolve(cache.getBranchPath(repoID, PR.id, 'head', 'gosec')))
 
     const output = mergeReports(banditReport, gosecReport)
     const resolvedCheckRunResponse = await checkRunResponse

--- a/test/gosec.report.test.js
+++ b/test/gosec.report.test.js
@@ -6,15 +6,15 @@ const { config } = require('../config')
 
 describe('Gosec report tests', () => {
   test('Empty result parameter', () => {
-    const trueReport = gosecReport('')
+    const trueReport = gosecReport('', '')
     expect(trueReport.title).toEqual(config.noIssuesResultTitle)
     expect(trueReport.summary).toEqual(config.noIssuesResultSummary)
     expect(trueReport.annotations).toBeFalsy()
   })
 
   test('Generate valid report', () => {
-    const midedResults = require('./fixtures/reports/gosec_mix_results.json')
-    const trueReport = gosecReport(midedResults)
+    const mixedResults = require('./fixtures/reports/gosec_mix_results.json')
+    const trueReport = gosecReport(mixedResults, './fixtures/reports/')
     expect(trueReport.title).toEqual(config.issuesFoundResultTitle)
     expect(trueReport.summary).not.toBe('')
     expect(trueReport.annotations.length).toBeGreaterThan(0)


### PR DESCRIPTION
Right now when there is a issue found by Gosec the path to the file will be the full path to the file in the machine where Precaution is working.

Here is an example: 
![image](https://user-images.githubusercontent.com/16246778/49803646-0efa4700-fd59-11e8-9eb5-77d6228126bb.png)

It's from this pull request: https://github.com/MVrachev/Travic-CI---Tests/pull/687/checks

Also as you can when you go to the 'Files changed' the issues are not shown there.

With this pull request I fix this with removing the unnecessary path from the issue.

Here is how it will be with this fix: 
![image](https://user-images.githubusercontent.com/16246778/49803750-60a2d180-fd59-11e8-9073-3472714272e0.png)

It's from this pull request: https://github.com/MVrachev/Travic-CI---Tests/pull/695/checks

As you can see in 'Files changed' tab the issues are now shown right where the problematic code is.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>