### PR TITLE
New summary

### DIFF
--- a/annotations_levels.js
+++ b/annotations_levels.js
@@ -3,15 +3,19 @@
 
 const { annotationsLevels } = require('./config')
 
+/**
+ * @param {Object[]} annotations the issues found by a security linter wrapped into this object:
+ * https://developer.github.com/v3/checks/runs/#annotations-object
+ */
 function countAnnotationLevels (annotations) {
   let errors = 0
   let warnings = 0
   let notices = 0
 
-  for (let i = 0; i < annotations.length; ++i) {
-    if (annotations[i].annotation_level === 'failure') {
+  for (let annotation of annotations) {
+    if (annotation.annotation_level === 'failure') {
       errors += 1
-    } else if (annotations[i].annotation_level === 'warning') {
+    } else if (annotation.annotation_level === 'warning') {
       warnings += 1
     } else {
       notices += 1

--- a/annotations_levels.js
+++ b/annotations_levels.js
@@ -3,6 +3,23 @@
 
 const { annotationsLevels } = require('./config')
 
+function countAnnotationLevels (annotations) {
+  let errors = 0
+  let warnings = 0
+  let notices = 0
+
+  for (let i = 0; i < annotations.length; ++i) {
+    if (annotations[i].annotation_level === 'failure') {
+      errors += 1
+    } else if (annotations[i].annotation_level === 'warning') {
+      warnings += 1
+    } else {
+      notices += 1
+    }
+  }
+  return { errors, warnings, notices }
+}
+
 /**
  * @param {String} severity issue severity from bandit analyze
  * @param {String} confidence issue confidence from bandit analyze
@@ -37,3 +54,4 @@ function getAnnotationLevel (severity, confidence) {
 }
 
 module.exports.getAnnotationLevel = getAnnotationLevel
+module.exports.countIssueLevels = countAnnotationLevels

--- a/bandit/bandit_report.js
+++ b/bandit/bandit_report.js
@@ -3,16 +3,15 @@
 
 const { config } = require('../config')
 const { getAnnotation } = require('./bandit_annotations')
+const { countIssueLevels } = require('../annotations_levels')
 
-function customSummary (banditSummary) {
-  let severityHigh = banditSummary['SEVERITY.HIGH']
-  let severityMedium = banditSummary['SEVERITY.MEDIUM']
-  let severityLow = banditSummary['SEVERITY.LOW']
+function customSummary (annotations) {
+  const { errors, warnings, notices } = countIssueLevels(annotations)
 
   const summary = {
-    'SEVERITY_HIGH': severityHigh,
-    'SEVERITY_MEDIUM': severityMedium,
-    'SEVERITY_LOW': severityLow
+    'errors': errors,
+    'warnings': warnings,
+    'notices': notices
   }
   return summary
 }
@@ -26,8 +25,9 @@ module.exports = (results) => {
 
   if (results && results.results.length !== 0) {
     title = config.issuesFoundResultTitle
-    summary = customSummary(results.metrics._totals)
     annotations = results.results.map(issue => getAnnotation(issue))
+
+    summary = customSummary(annotations)
   } else {
     title = config.noIssuesResultTitle
     summary = config.noIssuesResultSummary

--- a/github_api_helper.js
+++ b/github_api_helper.js
@@ -72,11 +72,11 @@ function getConclusion (annotations) {
   let conclusion = 'success'
 
   if (annotations) {
-    for (let i = 0; i < annotations.length; ++i) {
-      if (annotations[i].annotation_level === 'failure') {
+    for (let annotation of annotations) {
+      if (annotation.annotation_level === 'failure') {
         conclusion = 'failure'
         break
-      } else if (annotations[i].annotation_level === 'warning') {
+      } else if (annotation.annotation_level === 'warning') {
         conclusion = 'neutral'
       }
     }

--- a/gosec/gosec_report.js
+++ b/gosec/gosec_report.js
@@ -3,24 +3,15 @@
 
 const { config } = require('../config')
 const { getAnnotation } = require('./gosec_annotations')
+const { countIssueLevels } = require('../annotations_levels')
 
-function customSummary (gosecAnnotations) {
-  let severityHigh = 0
-  let severityMedium = 0
-  let severityLow = 0
-
-  for (let i = 0; i < gosecAnnotations.length; ++i) {
-    switch (gosecAnnotations[i].severity) {
-      case 'HIGH' : severityHigh += 1; break
-      case 'MEDIUM' : severityMedium += 1; break
-      case 'LOW' : severityLow += 1
-    }
-  }
+function customSummary (annotations) {
+  const { errors, warnings, notices } = countIssueLevels(annotations)
 
   const summary = {
-    'SEVERITY_HIGH': severityHigh,
-    'SEVERITY_MEDIUM': severityMedium,
-    'SEVERITY_LOW': severityLow
+    'errors': errors,
+    'warnings': warnings,
+    'notices': notices
   }
   return summary
 }
@@ -34,8 +25,8 @@ module.exports = (results, directory) => {
   let title, summary, annotations
   if (results && results.Issues.length !== 0) {
     title = config.issuesFoundResultTitle
-    summary = customSummary(results.Issues)
-    annotations = results.Issues.map(issue => getAnnotation(issue, directory))
+    annotations = results.Issues.map(issue => getAnnotation(issue))
+    summary = customSummary(annotations)
   } else {
     title = config.noIssuesResultTitle
     summary = config.noIssuesResultSummary

--- a/merge_reports.js
+++ b/merge_reports.js
@@ -9,13 +9,13 @@ const { config } = require('./config')
  */
 function getCorrectSummary (errors, warnings, notices) {
   let summary = ''
-  let errorPrefix = errors > 1 ? 'There were ' + errors + ' errors found.' : 'There was 1 error found.'
-  let warningPrefix = warnings > 1 ? 'There were ' + warnings + ' warnings found.' : 'There was 1 warning found.'
-  let noticePrefix = notices > 1 ? 'There were ' + notices + ' notices found.' : 'There was 1 notices.'
 
-  let errorsMessage = errorPrefix + ' The errors are marked in red.\n'
-  let warningsMessage = warningPrefix + ' The warnings are marked with orange.\n'
-  let noticesMessage = noticePrefix + ' The notices are marked in white.\n'
+  let errorsMessage = errors > 1 ? ':x: There were ' + errors + ' errors found.\n'
+    : ':x: There was 1 error found.\n'
+  let warningsMessage = warnings > 1 ? ':warning: There were ' + warnings + ' warnings found.\n'
+    : ':warning: There was 1 warning found.\n'
+  let noticesMessage = notices > 1 ? ':information_source: There were ' + notices + ' notices found.\n'
+    : ':information_source: There was 1 notice found.\n'
 
   summary += errors !== 0 ? errorsMessage : ''
   summary += warnings !== 0 ? warningsMessage : ''

--- a/merge_reports.js
+++ b/merge_reports.js
@@ -3,15 +3,15 @@
 
 const { config } = require('./config')
 /**
- * @param {Number} errors the amount of errors found
- * @param {Number} warnings the amount of warnings found
- * @param {Number} notices the amount of notices found
+ * @param {Number} errors the number of errors found
+ * @param {Number} warnings the number of warnings found
+ * @param {Number} notices the number of notices found
  */
 function getCorrectSummary (errors, warnings, notices) {
   let summary = ''
-  let errorPrefix = errors > 1 ? 'There where ' + errors + ' errors found.' : 'There is 1 error found.'
-  let warningPrefix = warnings > 1 ? 'There where ' + warnings + ' warnings found.' : 'There is 1 warning found.'
-  let noticePrefix = notices > 1 ? 'There where ' + notices + ' notices found.' : 'There is 1 notices.'
+  let errorPrefix = errors > 1 ? 'There were ' + errors + ' errors found.' : 'There was 1 error found.'
+  let warningPrefix = warnings > 1 ? 'There were ' + warnings + ' warnings found.' : 'There was 1 warning found.'
+  let noticePrefix = notices > 1 ? 'There were ' + notices + ' notices found.' : 'There was 1 notices.'
 
   let errorsMessage = errorPrefix + ' The errors are marked in red.\n'
   let warningsMessage = warningPrefix + ' The warnings are marked with orange.\n'

--- a/merge_reports.js
+++ b/merge_reports.js
@@ -2,28 +2,42 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 const { config } = require('./config')
+/**
+ * @param {Number} errors the amount of errors found
+ * @param {Number} warnings the amount of warnings found
+ * @param {Number} notices the amount of notices found
+ */
+function getCorrectSummary (errors, warnings, notices) {
+  let summary = ''
+  let errorPrefix = errors > 1 ? 'There where ' + errors + ' errors found.' : 'There is 1 error found.'
+  let warningPrefix = warnings > 1 ? 'There where ' + warnings + ' warnings found.' : 'There is 1 warning found.'
+  let noticePrefix = notices > 1 ? 'There where ' + notices + ' notices found.' : 'There is 1 notices.'
 
-function mergeSummaries (banditSummary, gosecSummary) {
-  let severityHigh, severityMedium, severityLow
+  let errorsMessage = errorPrefix + ' The errors are marked in red.\n'
+  let warningsMessage = warningPrefix + ' The warnings are marked with orange.\n'
+  let noticesMessage = noticePrefix + ' The notices are marked in white.\n'
 
-  if (banditSummary === config.noIssuesResultSummary) {
-    severityHigh = gosecSummary.SEVERITY_HIGH
-    severityMedium = gosecSummary.SEVERITY_MEDIUM
-    severityLow = gosecSummary.SEVERITY_LOW
-  } else if (gosecSummary === config.noIssuesResultSummary) {
-    severityHigh = banditSummary.SEVERITY_HIGH
-    severityMedium = banditSummary.SEVERITY_MEDIUM
-    severityLow = banditSummary.SEVERITY_LOW
-  } else {
-    severityHigh = banditSummary.SEVERITY_HIGH + gosecSummary.SEVERITY_HIGH
-    severityMedium = banditSummary.SEVERITY_MEDIUM + gosecSummary.SEVERITY_MEDIUM
-    severityLow = banditSummary.SEVERITY_LOW + gosecSummary.SEVERITY_LOW
-  }
-  let summary = 'SEVERITY_HIGH: ' + severityHigh + '\n'
-  summary += 'SEVERITY_MEDIUM: ' + severityMedium + '\n'
-  summary += 'SEVERITY_LOW: ' + severityLow + '\n'
+  summary += errors !== 0 ? errorsMessage : ''
+  summary += warnings !== 0 ? warningsMessage : ''
+  summary += notices !== 0 ? noticesMessage : ''
 
   return summary
+}
+
+function mergeSummaries (banditSummary, gosecSummary) {
+  let result = { errors: 0, warnings: 0, notices: 0 }
+
+  if (banditSummary === config.noIssuesResultSummary) {
+    result = gosecSummary
+  } else if (gosecSummary === config.noIssuesResultSummary) {
+    result = banditSummary
+  } else {
+    result.errors = banditSummary.errors + gosecSummary.errors
+    result.warnings = banditSummary.warnings + gosecSummary.warnings
+    result.notices = banditSummary.notices + gosecSummary.notices
+  }
+
+  return getCorrectSummary(result.errors, result.warnings, result.notices)
 }
 
 /**

--- a/test/merge.reports.test.js
+++ b/test/merge.reports.test.js
@@ -24,9 +24,9 @@ describe('Merge reports tests from Bandit and Gosec reports', () => {
     let banditReport = { title: config.issuesFoundResultTitle, summary: banditSummary, annotations: banditAnnotations }
     let gosecReport = { title: config.noIssuesResultTitle, summary: config.noIssuesResultSummary, annotations: [] }
 
-    let expectedSummary = 'There was 1 error found. The errors are marked in red.\n' +
-      'There was 1 warning found. The warnings are marked with orange.\n' +
-      'There was 1 notices. The notices are marked in white.\n'
+    let expectedSummary = ':x: There was 1 error found.\n' +
+      ':warning: There was 1 warning found.\n' +
+      ':information_source: There was 1 notice found.\n'
 
     const result = mergeReports(banditReport, gosecReport)
     expect(result.title).toEqual(config.issuesFoundResultTitle)
@@ -38,8 +38,8 @@ describe('Merge reports tests from Bandit and Gosec reports', () => {
     let banditReport = { title: config.noIssuesResultTitle, summary: config.noIssuesResultSummary, annotations: [] }
     let gosecReport = { title: config.issuesFoundResultTitle, summary: gosecSummary, annotations: gosecAnnotations }
 
-    let expectedSummary = 'There was 1 error found. The errors are marked in red.\n' +
-      'There was 1 warning found. The warnings are marked with orange.\n'
+    let expectedSummary = ':x: There was 1 error found.\n' +
+      ':warning: There was 1 warning found.\n'
 
     const result = mergeReports(banditReport, gosecReport)
     expect(result.title).toEqual(config.issuesFoundResultTitle)
@@ -51,9 +51,9 @@ describe('Merge reports tests from Bandit and Gosec reports', () => {
     let banditReport = { title: config.issuesFoundResultTitle, summary: banditSummary, annotations: banditAnnotations }
     let gosecReport = { title: config.issuesFoundResultTitle, summary: gosecSummary, annotations: gosecAnnotations }
 
-    let expectedSummary = 'There were 2 errors found. The errors are marked in red.\n' +
-      'There were 2 warnings found. The warnings are marked with orange.\n' +
-      'There was 1 notices. The notices are marked in white.\n'
+    let expectedSummary = ':x: There were 2 errors found.\n' +
+      ':warning: There were 2 warnings found.\n' +
+      ':information_source: There was 1 notice found.\n'
 
     let expectedAnnotations = []
     expectedAnnotations = expectedAnnotations.concat(gosecAnnotations, banditAnnotations)

--- a/test/merge.reports.test.js
+++ b/test/merge.reports.test.js
@@ -6,8 +6,8 @@ const mergeReports = require('../merge_reports')
 const banditAnnotations = require('./fixtures/annotations/mixed_levels_annotations.json').annotations
 const gosecAnnotations = require('./fixtures/annotations/gosec_mix_annotations.json').annotations
 
-const banditSummary = { SEVERITY_HIGH: 1, SEVERITY_MEDIUM: 3, SEVERITY_LOW: 0 }
-const gosecSummary = { SEVERITY_HIGH: 4, SEVERITY_MEDIUM: 3, SEVERITY_LOW: 1 }
+const banditSummary = { errors: 1, warnings: 1, notices: 1 }
+const gosecSummary = { errors: 1, warnings: 1, notices: 0 }
 
 describe('Merge reports tests from Bandit and Gosec reports', () => {
   test('No issues found from both Gosec and Bandit', () => {
@@ -24,8 +24,9 @@ describe('Merge reports tests from Bandit and Gosec reports', () => {
     let banditReport = { title: config.issuesFoundResultTitle, summary: banditSummary, annotations: banditAnnotations }
     let gosecReport = { title: config.noIssuesResultTitle, summary: config.noIssuesResultSummary, annotations: [] }
 
-    const expectedSummary = 'SEVERITY_HIGH: ' + banditSummary.SEVERITY_HIGH + '\n' + 'SEVERITY_MEDIUM: ' +
-      banditSummary.SEVERITY_MEDIUM + '\n' + 'SEVERITY_LOW: ' + banditSummary.SEVERITY_LOW + '\n'
+    let expectedSummary = 'There is 1 error found. The errors are marked in red.\n' +
+      'There is 1 warning found. The warnings are marked with orange.\n' +
+      'There is 1 notices. The notices are marked in white.\n'
 
     const result = mergeReports(banditReport, gosecReport)
     expect(result.title).toEqual(config.issuesFoundResultTitle)
@@ -37,8 +38,8 @@ describe('Merge reports tests from Bandit and Gosec reports', () => {
     let banditReport = { title: config.noIssuesResultTitle, summary: config.noIssuesResultSummary, annotations: [] }
     let gosecReport = { title: config.issuesFoundResultTitle, summary: gosecSummary, annotations: gosecAnnotations }
 
-    const expectedSummary = 'SEVERITY_HIGH: ' + gosecSummary.SEVERITY_HIGH + '\n' + 'SEVERITY_MEDIUM: ' +
-      gosecSummary.SEVERITY_MEDIUM + '\n' + 'SEVERITY_LOW: ' + gosecSummary.SEVERITY_LOW + '\n'
+    let expectedSummary = 'There is 1 error found. The errors are marked in red.\n' +
+      'There is 1 warning found. The warnings are marked with orange.\n'
 
     const result = mergeReports(banditReport, gosecReport)
     expect(result.title).toEqual(config.issuesFoundResultTitle)
@@ -50,8 +51,9 @@ describe('Merge reports tests from Bandit and Gosec reports', () => {
     let banditReport = { title: config.issuesFoundResultTitle, summary: banditSummary, annotations: banditAnnotations }
     let gosecReport = { title: config.issuesFoundResultTitle, summary: gosecSummary, annotations: gosecAnnotations }
 
-    const expectedSummary = 'SEVERITY_HIGH: ' + 5 + '\n' + 'SEVERITY_MEDIUM: ' + 6 +
-      '\n' + 'SEVERITY_LOW: ' + 1 + '\n'
+    let expectedSummary = 'There where 2 errors found. The errors are marked in red.\n' +
+      'There where 2 warnings found. The warnings are marked with orange.\n' +
+      'There is 1 notices. The notices are marked in white.\n'
 
     let expectedAnnotations = []
     expectedAnnotations = expectedAnnotations.concat(gosecAnnotations, banditAnnotations)

--- a/test/merge.reports.test.js
+++ b/test/merge.reports.test.js
@@ -24,9 +24,9 @@ describe('Merge reports tests from Bandit and Gosec reports', () => {
     let banditReport = { title: config.issuesFoundResultTitle, summary: banditSummary, annotations: banditAnnotations }
     let gosecReport = { title: config.noIssuesResultTitle, summary: config.noIssuesResultSummary, annotations: [] }
 
-    let expectedSummary = 'There is 1 error found. The errors are marked in red.\n' +
-      'There is 1 warning found. The warnings are marked with orange.\n' +
-      'There is 1 notices. The notices are marked in white.\n'
+    let expectedSummary = 'There was 1 error found. The errors are marked in red.\n' +
+      'There was 1 warning found. The warnings are marked with orange.\n' +
+      'There was 1 notices. The notices are marked in white.\n'
 
     const result = mergeReports(banditReport, gosecReport)
     expect(result.title).toEqual(config.issuesFoundResultTitle)
@@ -38,8 +38,8 @@ describe('Merge reports tests from Bandit and Gosec reports', () => {
     let banditReport = { title: config.noIssuesResultTitle, summary: config.noIssuesResultSummary, annotations: [] }
     let gosecReport = { title: config.issuesFoundResultTitle, summary: gosecSummary, annotations: gosecAnnotations }
 
-    let expectedSummary = 'There is 1 error found. The errors are marked in red.\n' +
-      'There is 1 warning found. The warnings are marked with orange.\n'
+    let expectedSummary = 'There was 1 error found. The errors are marked in red.\n' +
+      'There was 1 warning found. The warnings are marked with orange.\n'
 
     const result = mergeReports(banditReport, gosecReport)
     expect(result.title).toEqual(config.issuesFoundResultTitle)
@@ -51,9 +51,9 @@ describe('Merge reports tests from Bandit and Gosec reports', () => {
     let banditReport = { title: config.issuesFoundResultTitle, summary: banditSummary, annotations: banditAnnotations }
     let gosecReport = { title: config.issuesFoundResultTitle, summary: gosecSummary, annotations: gosecAnnotations }
 
-    let expectedSummary = 'There where 2 errors found. The errors are marked in red.\n' +
-      'There where 2 warnings found. The warnings are marked with orange.\n' +
-      'There is 1 notices. The notices are marked in white.\n'
+    let expectedSummary = 'There were 2 errors found. The errors are marked in red.\n' +
+      'There were 2 warnings found. The warnings are marked with orange.\n' +
+      'There was 1 notices. The notices are marked in white.\n'
 
     let expectedAnnotations = []
     expectedAnnotations = expectedAnnotations.concat(gosecAnnotations, banditAnnotations)


### PR DESCRIPTION
I changed our summary. The messages now are making more sense.

This is fix for issues https://github.com/vmware/precaution/issues/64
 
Because there are many possible situation I wanted to make the code smaller as possible.
I hope it's readable.

I had to change besides merge_reports also the bandit and gosec report functions so they will give summary relative to the new merged summary. Now I get the amount of errors, warnings and notices from the annotations of Gosec and Bandit not from the raw summary given by Gosec and Bandit.

I added a useful function with which I count the amount of errors, warnings and notices in annotation array in annotations_levels.

Also I had to change the tests in test/merge.reports.test.js so they won't fail.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>