### PR TITLE
Fix deletion

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -56,8 +56,8 @@ function saveFileToPRCache (repoID, prID, branchTag, filePath, data, fileType) {
  * @param {number} prID pull request identifier
  */
 function clearPRCache (repoID, prID) {
-  fs.removeSync(path.join('cache', repoID.toString(), prID.toString()))
-  fs.removeSync(path.join('cache/go/src', repoID.toString(), prID.toString()))
+  fs.removeSync(path.join('cache', repoID.toString()))
+  fs.removeSync(path.join('cache/go/src', repoID.toString()))
 }
 
 /**


### PR DESCRIPTION
I noticed that we delete the folder cache/prID/repoID not the whole cache/prID folder.

I we don't need to keep the pr-s subfolders.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>