### PR TITLE
Add more info links on Bandit issues

### DIFF
--- a/bandit/bandit_annotations.js
+++ b/bandit/bandit_annotations.js
@@ -14,7 +14,7 @@ function getAnnotation (issue) {
   const endLine = issue.line_number
   const annotationLevel = getAnnotationLevel(issue.issue_severity, issue.issue_confidence)
   const title = `${issue.test_id}:${issue.test_name}`
-  const message = issue.issue_text
+  const message = issue.issue_text + '\nMore info about the issue can be found here:\n' + issue.more_info
 
   return {
     path,


### PR DESCRIPTION
The json output of Bandit gives us a "more_info" weblink where there is more information about the issue.
Here is an example how it will work with this format of the issues found by Bandit:
https://github.com/MVrachev/Travic-CI---Tests/pull/724/checks?check_run_id=41872903

Gosec for now doesn't support such a thing. :(

Hopefully in future they will support this. I follow this thread for this topic:
https://github.com/securego/gosec/issues/127

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>