### PR TITLE
Fixed incorrect cleanup test

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -201,7 +201,7 @@ describe('Bandit-linter', () => {
     test('cleans up after performing checks', async () => {
       await app.receive(checkSuiteRerequestedEvent)
 
-      expect(fs.existsSync('cache/210857942')).toBeFalsy()
+      expect(fs.existsSync('cache/54321/2108')).toBeFalsy()
     })
 
     test('sends an error report on crash', async () => {


### PR DESCRIPTION
After #54 I forgot to update the related test, it was passing for the wrong reasons as it checked an incorrect folder path.

Signed-off-by: Antoine Salon <asalon@vmware.com>