### PR TITLE
New summary

### DIFF
--- a/annotations_levels.js
+++ b/annotations_levels.js
@@ -4,6 +4,27 @@
 const { annotationsLevels } = require('./config')
 
 /**
+ * @param {Object[]} annotations the issues found by a security linter wrapped into this object:
+ * https://developer.github.com/v3/checks/runs/#annotations-object
+ */
+function countAnnotationLevels (annotations) {
+  let errors = 0
+  let warnings = 0
+  let notices = 0
+
+  for (let annotation of annotations) {
+    if (annotation.annotation_level === 'failure') {
+      errors += 1
+    } else if (annotation.annotation_level === 'warning') {
+      warnings += 1
+    } else {
+      notices += 1
+    }
+  }
+  return { errors, warnings, notices }
+}
+
+/**
  * @param {String} severity issue severity from bandit analyze
  * @param {String} confidence issue confidence from bandit analyze
  * @returns {String} the true annotation level
@@ -37,3 +58,4 @@ function getAnnotationLevel (severity, confidence) {
 }
 
 module.exports.getAnnotationLevel = getAnnotationLevel
+module.exports.countIssueLevels = countAnnotationLevels

--- a/bandit/bandit_report.js
+++ b/bandit/bandit_report.js
@@ -10,7 +10,7 @@ const { countIssueLevels } = require('../annotations_levels')
  */
 function createMoreInfoLinks (issues) {
   let issuesMap = new Map()
-  let moreInfo = 'For more information about the issues refer to the following: \n'
+  let moreInfo = 'For more information about the issues follow the links: \n'
 
   for (let issue of issues) {
     if (issuesMap.has(issue.test_id) === false) {
@@ -23,31 +23,19 @@ function createMoreInfoLinks (issues) {
 }
 
 /**
- * @param {*} annotations all issues found by Bandit wrapped in the annotation object
- * see: https://developer.github.com/v3/checks/runs/#annotations-object
- */
-function customSummary (annotations) {
-  const { errors, warnings, notices } = countIssueLevels(annotations)
-
-  const summary = {
-    'errors': errors,
-    'warnings': warnings,
-    'notices': notices
-  }
-  return summary
-}
-
-/**
  * Convert bandit output into valid 'output' object for check run conclusion
  * @param {any} results Bandit json output
  */
 module.exports = (results) => {
-  let title, summary, annotations, moreInfo
+  let title = ''
+  let summary = ''
+  let annotations = []
+  let moreInfo = ''
 
   if (results && results.results.length !== 0) {
     title = config.issuesFoundResultTitle
     annotations = results.results.map(issue => getAnnotation(issue))
-    summary = customSummary(annotations)
+    summary = countIssueLevels(annotations)
     moreInfo = createMoreInfoLinks(results.results)
   } else {
     title = config.noIssuesResultTitle

--- a/bandit/bandit_report.js
+++ b/bandit/bandit_report.js
@@ -10,7 +10,7 @@ const { countIssueLevels } = require('../annotations_levels')
  */
 function createMoreInfoLinks (issues) {
   let issuesMap = new Map()
-  let moreInfo = 'For more information about the issues follow the links: \n'
+  let moreInfo = 'For more information about the issues refer to the following: \n'
 
   for (let issue of issues) {
     if (issuesMap.has(issue.test_id) === false) {

--- a/github_api_helper.js
+++ b/github_api_helper.js
@@ -72,11 +72,11 @@ function getConclusion (annotations) {
   let conclusion = 'success'
 
   if (annotations) {
-    for (let i = 0; i < annotations.length; ++i) {
-      if (annotations[i].annotation_level === 'failure') {
+    for (let annotation of annotations) {
+      if (annotation.annotation_level === 'failure') {
         conclusion = 'failure'
         break
-      } else if (annotations[i].annotation_level === 'warning') {
+      } else if (annotation.annotation_level === 'warning') {
         conclusion = 'neutral'
       }
     }

--- a/gosec/gosec_report.js
+++ b/gosec/gosec_report.js
@@ -3,27 +3,7 @@
 
 const { config } = require('../config')
 const { getAnnotation } = require('./gosec_annotations')
-
-function customSummary (gosecAnnotations) {
-  let severityHigh = 0
-  let severityMedium = 0
-  let severityLow = 0
-
-  for (let i = 0; i < gosecAnnotations.length; ++i) {
-    switch (gosecAnnotations[i].severity) {
-      case 'HIGH' : severityHigh += 1; break
-      case 'MEDIUM' : severityMedium += 1; break
-      case 'LOW' : severityLow += 1
-    }
-  }
-
-  const summary = {
-    'SEVERITY_HIGH': severityHigh,
-    'SEVERITY_MEDIUM': severityMedium,
-    'SEVERITY_LOW': severityLow
-  }
-  return summary
-}
+const { countIssueLevels } = require('../annotations_levels')
 
 /**
  *
@@ -31,11 +11,14 @@ function customSummary (gosecAnnotations) {
  * @param {*} directory working directory for Gosec process
  */
 module.exports = (results, directory) => {
-  let title, summary, annotations
+  let title = ''
+  let summary = ''
+  let annotations = []
+
   if (results && results.Issues.length !== 0) {
     title = config.issuesFoundResultTitle
-    summary = customSummary(results.Issues)
     annotations = results.Issues.map(issue => getAnnotation(issue, directory))
+    summary = countIssueLevels(annotations)
   } else {
     title = config.noIssuesResultTitle
     summary = config.noIssuesResultSummary

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = app => {
 }
 
 /**
- * Retrive files modified by pull request(s), run linter and send results
+ * Retrieve files modified by pull request(s), run linter and send results
  * @param {any[]} pullRequests
  * @param {import('probot').Context} context
  * @param {string} headSha

--- a/merge_reports.js
+++ b/merge_reports.js
@@ -57,12 +57,11 @@ module.exports = (banditReport, gosecReport) => {
   if (banditReport.title === config.noIssuesResultTitle && banditReport.title === gosecReport.title) {
     title = config.noIssuesResultTitle
     summary = config.noIssuesResultSummary
-    return { title, summary }
+  } else {
+    title = config.issuesFoundResultTitle
+    summary = mergeSummaries(banditReport.summary, gosecReport.summary)
+    text = banditReport.moreInfo
   }
-
-  title = config.issuesFoundResultTitle
-  summary = mergeSummaries(banditReport.summary, gosecReport.summary)
-  text = banditReport.moreInfo
 
   if (!gosecReport.annotations) {
     annotations = banditReport.annotations

--- a/merge_reports.js
+++ b/merge_reports.js
@@ -4,7 +4,7 @@
 const { config } = require('./config')
 
 /**
- * Creates the final summary based on how many errors, warnings and notices there is
+ * Creates the final summary message describing the number of errors, warnings and notices.
  * so the final summary to be meaningful.
  * @param {Number} errors the number of errors found
  * @param {Number} warnings the number of warnings found

--- a/merge_reports.js
+++ b/merge_reports.js
@@ -4,18 +4,20 @@
 const { config } = require('./config')
 
 /**
+ * Creates the final summary based on how many errors, warnings and notices there is
+ * so the final summary to be meaningful.
  * @param {Number} errors the number of errors found
  * @param {Number} warnings the number of warnings found
  * @param {Number} notices the number of notices found
  */
-function getCorrectSummary (errors, warnings, notices) {
+function createFinalSummaryMessage (errors, warnings, notices) {
   let summary = ''
 
-  let errorsMessage = errors > 1 ? ':x: ' + errors + ' errors\n'
+  const errorsMessage = errors > 1 ? ':x: ' + errors + ' errors\n'
     : ':x: 1 error\n'
-  let warningsMessage = warnings > 1 ? ':warning: ' + warnings + ' warnings\n'
+  const warningsMessage = warnings > 1 ? ':warning: ' + warnings + ' warnings\n'
     : ':warning: 1 warning\n'
-  let noticesMessage = notices > 1 ? ':information_source: ' + notices + ' notices\n'
+  const noticesMessage = notices > 1 ? ':information_source: ' + notices + ' notices\n'
     : ':information_source: 1 notice\n'
 
   summary += errors !== 0 ? errorsMessage : ''
@@ -38,7 +40,7 @@ function mergeSummaries (banditSummary, gosecSummary) {
     result.notices = banditSummary.notices + gosecSummary.notices
   }
 
-  return getCorrectSummary(result.errors, result.warnings, result.notices)
+  return createFinalSummaryMessage(result.errors, result.warnings, result.notices)
 }
 
 /**
@@ -47,17 +49,20 @@ function mergeSummaries (banditSummary, gosecSummary) {
  * for reference of the 'output' object see: https://developer.github.com/v3/checks/runs/#output-object
  */
 module.exports = (banditReport, gosecReport) => {
-  let title, summary, text
+  let title = ''
+  let summary = ''
+  let text = ''
   let annotations = []
 
   if (banditReport.title === config.noIssuesResultTitle && banditReport.title === gosecReport.title) {
     title = config.noIssuesResultTitle
     summary = config.noIssuesResultSummary
-  } else {
-    title = config.issuesFoundResultTitle
-    summary = mergeSummaries(banditReport.summary, gosecReport.summary)
-    text = banditReport.moreInfo
+    return { title, summary }
   }
+
+  title = config.issuesFoundResultTitle
+  summary = mergeSummaries(banditReport.summary, gosecReport.summary)
+  text = banditReport.moreInfo
 
   if (!gosecReport.annotations) {
     annotations = banditReport.annotations

--- a/merge_reports.js
+++ b/merge_reports.js
@@ -5,7 +5,6 @@ const { config } = require('./config')
 
 /**
  * Creates the final summary message describing the number of errors, warnings and notices.
- * so the final summary to be meaningful.
  * @param {Number} errors the number of errors found
  * @param {Number} warnings the number of warnings found
  * @param {Number} notices the number of notices found

--- a/test/bandit.report.test.js
+++ b/test/bandit.report.test.js
@@ -33,9 +33,8 @@ describe('Report generation', () => {
 
   test('Handles empty reports', () => {
     const report = generateReport(null)
-
-    expect(report).toHaveProperty('summary')
     expect(report).toHaveProperty('annotations')
+    expect(report).toHaveProperty('summary')
     expect(report).toHaveProperty('title')
   })
 
@@ -48,6 +47,6 @@ describe('Report generation', () => {
 
     expect(trueReport.title).toEqual(config.noIssuesResultTitle)
     expect(trueReport.summary).toEqual(config.noIssuesResultSummary)
-    expect(trueReport.annotations).toBeFalsy()
+    expect(trueReport.annotations.length).toEqual(0)
   })
 })

--- a/test/gosec.report.test.js
+++ b/test/gosec.report.test.js
@@ -9,7 +9,7 @@ describe('Gosec report tests', () => {
     const trueReport = gosecReport('', '')
     expect(trueReport.title).toEqual(config.noIssuesResultTitle)
     expect(trueReport.summary).toEqual(config.noIssuesResultSummary)
-    expect(trueReport.annotations).toBeFalsy()
+    expect(trueReport.annotations.length).toEqual(0)
   })
 
   test('Generate valid report', () => {

--- a/test/merge.reports.test.js
+++ b/test/merge.reports.test.js
@@ -6,8 +6,8 @@ const mergeReports = require('../merge_reports')
 const banditAnnotations = require('./fixtures/annotations/mixed_levels_annotations.json').annotations
 const gosecAnnotations = require('./fixtures/annotations/gosec_mix_annotations.json').annotations
 
-const banditSummary = { SEVERITY_HIGH: 1, SEVERITY_MEDIUM: 3, SEVERITY_LOW: 0 }
-const gosecSummary = { SEVERITY_HIGH: 4, SEVERITY_MEDIUM: 3, SEVERITY_LOW: 1 }
+const banditSummary = { errors: 1, warnings: 1, notices: 1 }
+const gosecSummary = { errors: 1, warnings: 1, notices: 0 }
 
 describe('Merge reports tests from Bandit and Gosec reports', () => {
   test('No issues found from both Gosec and Bandit', () => {
@@ -24,8 +24,9 @@ describe('Merge reports tests from Bandit and Gosec reports', () => {
     let banditReport = { title: config.issuesFoundResultTitle, summary: banditSummary, annotations: banditAnnotations }
     let gosecReport = { title: config.noIssuesResultTitle, summary: config.noIssuesResultSummary, annotations: [] }
 
-    const expectedSummary = 'SEVERITY_HIGH: ' + banditSummary.SEVERITY_HIGH + '\n' + 'SEVERITY_MEDIUM: ' +
-      banditSummary.SEVERITY_MEDIUM + '\n' + 'SEVERITY_LOW: ' + banditSummary.SEVERITY_LOW + '\n'
+    let expectedSummary = ':x: 1 error\n' +
+      ':warning: 1 warning\n' +
+      ':information_source: 1 notice\n'
 
     const result = mergeReports(banditReport, gosecReport)
     expect(result.title).toEqual(config.issuesFoundResultTitle)
@@ -37,8 +38,8 @@ describe('Merge reports tests from Bandit and Gosec reports', () => {
     let banditReport = { title: config.noIssuesResultTitle, summary: config.noIssuesResultSummary, annotations: [] }
     let gosecReport = { title: config.issuesFoundResultTitle, summary: gosecSummary, annotations: gosecAnnotations }
 
-    const expectedSummary = 'SEVERITY_HIGH: ' + gosecSummary.SEVERITY_HIGH + '\n' + 'SEVERITY_MEDIUM: ' +
-      gosecSummary.SEVERITY_MEDIUM + '\n' + 'SEVERITY_LOW: ' + gosecSummary.SEVERITY_LOW + '\n'
+    let expectedSummary = ':x: 1 error\n' +
+      ':warning: 1 warning\n'
 
     const result = mergeReports(banditReport, gosecReport)
     expect(result.title).toEqual(config.issuesFoundResultTitle)
@@ -50,8 +51,9 @@ describe('Merge reports tests from Bandit and Gosec reports', () => {
     let banditReport = { title: config.issuesFoundResultTitle, summary: banditSummary, annotations: banditAnnotations }
     let gosecReport = { title: config.issuesFoundResultTitle, summary: gosecSummary, annotations: gosecAnnotations }
 
-    const expectedSummary = 'SEVERITY_HIGH: ' + 5 + '\n' + 'SEVERITY_MEDIUM: ' + 6 +
-      '\n' + 'SEVERITY_LOW: ' + 1 + '\n'
+    let expectedSummary = ':x: 2 errors\n' +
+      ':warning: 2 warnings\n' +
+      ':information_source: 1 notice\n'
 
     let expectedAnnotations = []
     expectedAnnotations = expectedAnnotations.concat(gosecAnnotations, banditAnnotations)

--- a/test/merge.reports.test.js
+++ b/test/merge.reports.test.js
@@ -11,20 +11,19 @@ const gosecSummary = { errors: 1, warnings: 1, notices: 0 }
 
 describe('Merge reports tests from Bandit and Gosec reports', () => {
   test('No issues found from both Gosec and Bandit', () => {
-    let banditReport = { title: config.noIssuesResultTitle, summary: config.noIssuesResultSummary, annotations: [] }
-    let gosecReport = { title: config.noIssuesResultTitle, summary: config.noIssuesResultSummary, annotations: [] }
+    const banditReport = { title: config.noIssuesResultTitle, summary: config.noIssuesResultSummary, annotations: [] }
+    const gosecReport = { title: config.noIssuesResultTitle, summary: config.noIssuesResultSummary, annotations: [] }
 
     const result = mergeReports(banditReport, gosecReport)
     expect(result.title).toEqual(config.noIssuesResultTitle)
     expect(result.summary).toEqual(config.noIssuesResultSummary)
-    expect(result.annotations.length).toBe(0)
   })
 
   test('Issues found by Bandit and no issues found by Gosec', () => {
-    let banditReport = { title: config.issuesFoundResultTitle, summary: banditSummary, annotations: banditAnnotations }
-    let gosecReport = { title: config.noIssuesResultTitle, summary: config.noIssuesResultSummary, annotations: [] }
+    const banditReport = { title: config.issuesFoundResultTitle, summary: banditSummary, annotations: banditAnnotations }
+    const gosecReport = { title: config.noIssuesResultTitle, summary: config.noIssuesResultSummary, annotations: [] }
 
-    let expectedSummary = ':x: 1 error\n' +
+    const expectedSummary = ':x: 1 error\n' +
       ':warning: 1 warning\n' +
       ':information_source: 1 notice\n'
 
@@ -35,10 +34,10 @@ describe('Merge reports tests from Bandit and Gosec reports', () => {
   })
 
   test('No issues found by Bandit but issues are found by Gosec', () => {
-    let banditReport = { title: config.noIssuesResultTitle, summary: config.noIssuesResultSummary, annotations: [] }
-    let gosecReport = { title: config.issuesFoundResultTitle, summary: gosecSummary, annotations: gosecAnnotations }
+    const banditReport = { title: config.noIssuesResultTitle, summary: config.noIssuesResultSummary, annotations: [] }
+    const gosecReport = { title: config.issuesFoundResultTitle, summary: gosecSummary, annotations: gosecAnnotations }
 
-    let expectedSummary = ':x: 1 error\n' +
+    const expectedSummary = ':x: 1 error\n' +
       ':warning: 1 warning\n'
 
     const result = mergeReports(banditReport, gosecReport)
@@ -48,10 +47,10 @@ describe('Merge reports tests from Bandit and Gosec reports', () => {
   })
 
   test('Issues found by Bandit and by Gosec', () => {
-    let banditReport = { title: config.issuesFoundResultTitle, summary: banditSummary, annotations: banditAnnotations }
-    let gosecReport = { title: config.issuesFoundResultTitle, summary: gosecSummary, annotations: gosecAnnotations }
+    const banditReport = { title: config.issuesFoundResultTitle, summary: banditSummary, annotations: banditAnnotations }
+    const gosecReport = { title: config.issuesFoundResultTitle, summary: gosecSummary, annotations: gosecAnnotations }
 
-    let expectedSummary = ':x: 2 errors\n' +
+    const expectedSummary = ':x: 2 errors\n' +
       ':warning: 2 warnings\n' +
       ':information_source: 1 notice\n'
 


### PR DESCRIPTION
I changed our summary. The messages now are making more sense.

Closes: https://github.com/vmware/precaution/issues/64

In this summary the annotations:
- with level 'failure' are errors
- with level 'warning' are warnings
- with level 'notice' are notices

Also I added a "text" field in the output object.
There I used that Bandit provides "more info" field for its issues. In the "more info" there is a link leading to the Bandit documentation of the issue.

Sadly Gosec doesn't support that now. :(

Here is an example how the new summary will look: 
![image](https://user-images.githubusercontent.com/16246778/50308014-bfc3bd00-04a2-11e9-8845-8e891c434cc2.png)

It is from this example: 
https://github.com/MVrachev/Travic-CI---Tests/pull/772/checks?check_run_id=43369277

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>