### PR TITLE
Use if exists the Bandit config file

### DIFF
--- a/bandit/bandit.js
+++ b/bandit/bandit.js
@@ -4,6 +4,7 @@
 const { spawn } = require('child_process')
 const path = require('path')
 const parseOutput = require('../parse_output')
+const fs = require('fs')
 
 /**
  * Spawn a bandit process analyzing all given files in provided directory
@@ -25,6 +26,11 @@ module.exports = (directory, inputFiles, params) => {
   const reportPath = path.join(directory, params.reportFile)
 
   let banditArgs = [...pyFiles, '--format', 'json', '-o', params.reportFile]
+
+  if (fs.existsSync(path.resolve('.bandit'))) {
+    banditArgs.push('-c', path.resolve('.bandit'))
+  }
+
   if (params.baselineFile) {
     banditArgs.push('--baseline', params.baselineFile)
   }


### PR DESCRIPTION
If the user creates a ".bandit" file in this format:
https://github.com/PyCQA/bandit#configuration
we would use those options when we run Bandit.

An example of a ".bandit" configuration file:
https://docs.openstack.org/bandit/latest/config.html

P.S. I am searching for a way to define a gosec config file but is little unclear for me.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>