### PR TITLE
Add precaution config file

### DIFF
--- a/.precaution.ymal.example
+++ b/.precaution.ymal.example
@@ -1,0 +1,13 @@
+# Copyright 2018 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+
+# That way you can say which security linters do you want to skip
+skip_linters: 'bandit'
+
+# Example of Bandit specific options
+# All of them can be found here: https://github.com/PyCQA/bandit#configuration
+bandit:
+ targets: './test'
+ exclude: './cache'
+ skips: 'B101'
+ tests: ['B309', 'B203']

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "fs-extra": "^7.0.0",
+    "js-yaml": "^3.12.0",
     "probot": "^7.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This pr is about this issues: https://github.com/vmware/precaution/issues/67 

We will need one more dependency: https://github.com/nodeca/js-yaml
It is not that easy to read properly a ymal file.
If you read it with fs.readFileSync you will have the content of a file as a string, not with objects which has properties.
Many people give an advice to use this library when dealing with ymal files.

I think that we can read for "skip_linters" key in our ymal file. With skip_linters the user can say which linters he want to skip when using Precaution.
Maybe it will be a good idea to give linter specific options. Like those for Bandit:
https://github.com/PyCQA/bandit#configuration

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>