### PR TITLE
Add coverage test runner and code coverage badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ install:
   - pip3 install --user -r requirements.txt
   - curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $GOPATH/bin 1.2.0
   - export GOPATH=$GOPATH:${TRAVIS_BUILD_DIR}/test/fixtures/go
+  - npm install -g codecov
+
+script:
+   - yarn test
+   - codecov
 
 language: node_js
 node_js:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 # Precaution
 
 [![Build Status](https://travis-ci.com/vmware/precaution.svg?branch=master)](https://travis-ci.com/vmware/precaution)
+[![Coverage Status](https://codecov.io/gh/vmware/precaution/branch/master/graph/badge.svg)](https://codecov.io/gh/vmware/precaution)
 [![License](https://img.shields.io/badge/License-BSD%202--Clause-orange.svg)](https://github.com/vmware/precaution/blob/master/LICENSE.txt)
 [![Slack](https://img.shields.io/badge/slack-join%20chat%20%E2%86%92-e01563.svg)](https://code.vmware.com/web/code/join)
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
     "testEnvironment": "node",
     "roots": [
       "test"
-    ]
+    ],
+    "coverageDirectory": "./coverage/",
+    "collectCoverage": true
   },
   "standard": {
     "globals": [


### PR DESCRIPTION
I use jest and Codecov tool (see codecov.io) to generate a badge about our projects code coverage.
I have to call yarn test which calls jest explicitly if I want to use this tool.
Look here: [CodeCov Node js examples](https://github.com/codecov/example-node#jest).

Codecov use Travis CI to run tests and gather information about the code coverage.

I tested and this badge is dynamically updated on every commit.

You can see how it looks here:
https://github.com/securego/gosec

This badge is configured for the master branch of precaution and that's why you can't see how it looks on my fork.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>