### PR TITLE
Fix for rerequest button doesn't work

### DIFF
--- a/github_api_helper.js
+++ b/github_api_helper.js
@@ -88,7 +88,7 @@ function getConclusion (annotations) {
 /**
  * Send check run results
  * @param {import('probot').Context} context Probot context
- * @param {Number} runID chek run identifier
+ * @param {Number} runID check run identifier
  * @param {Object} output output from the scan of Gosec and Bandit
  * @returns {Promise<any>} GitHub response
  * See: https://developer.github.com/v3/checks/runs/#update-a-check-run

--- a/index.js
+++ b/index.js
@@ -40,6 +40,16 @@ module.exports = app => {
     }
   })
 
+  app.on('check_run', async context => {
+    const action = context.payload.action
+    const headSha = context.payload.check_run.head_sha
+    const pullRequests = context.payload.check_run.pull_requests
+    if (action === 'rerequested') {
+      // Check suite was manually rerequested by a user on the checks dashboard
+      await runLinterFromPRData(pullRequests, context, headSha)
+    }
+  })
+
   app.on(['pull_request.opened', 'pull_request.reopened'], async context => {
     // Same thing but have to intercept the event because check suite is not triggered
     const pullRequest = context.payload.pull_request

--- a/test/events/check_run_rerequested.json
+++ b/test/events/check_run_rerequested.json
@@ -1,0 +1,40 @@
+{
+  "name": "check_run",
+  "payload": {
+    "action": "rerequested",
+    "check_run": {
+      "id": 100,
+      "head_branch": "head_branch",
+      "head_sha": "head_sha",
+      "status": "queued",
+      "before": "before_sha",
+      "after": "after_sha",
+      "pull_requests": [
+        {
+          "id": 2108,
+          "number": 6,
+          "head": {
+            "ref": "head_ref",
+            "sha": "head_sha"
+          },
+          "base": {
+            "ref": "base_ref",
+            "sha": "base_sha"
+          }
+        }
+      ],
+      "head_commit": {
+        "id": "commit_id",
+        "tree_id": "tree_id"
+      }
+    },
+    "repository": {
+      "id": 54321,
+      "name": "repo_name",
+      "full_name": "owner_login/repo_name",
+      "owner": {
+        "login": "owner_login"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes: https://github.com/vmware/precaution/issues/80

The problem was that when the user clicked the "Re-run" button then there would be created a check run rerequest even instead of a check suite rerequest event.

![image](https://user-images.githubusercontent.com/16246778/50897607-50901780-1415-11e9-8a3a-43d9c9bde28f.png)

I added a small code that catches that case and I created a new unit test in index.test.js and a new file check_run_rerequested.json.

The file was needed to check if we catch the check run rerequest event correctly.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>