### PR TITLE
Remove all baseline related code

### DIFF
--- a/config.js
+++ b/config.js
@@ -3,7 +3,6 @@
 
 const config = {
   cleanupAfterRun: true,
-  compareAgainstBaseline: false,
   fileExtensions: ['.py', '.pyw', '.go'],
   checkRunName: 'Precaution',
   noIssuesResultTitle: 'No issues found',


### PR DESCRIPTION
The baseline feature is now irrelevant since we rely on GitHub to correctly filter the annotations and only display relevant ones.

This is split off from #78 to help trim it down.