### PR TITLE
script: run standard before test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "dev": "nodemon --exec \"npm start\"",
     "start": "probot run ./index.js",
-    "test": "LOG_LEVEL=error jest && standard",
+    "test": "standard && LOG_LEVEL=error jest",
     "test:watch": "LOG_LEVEL=error jest --watch --notify --notifyMode=change --coverage",
     "lint": "standard --fix"
   },


### PR DESCRIPTION
Makes it easier to catch style errors quickly even when tests fail.

Signed-off-by: Antoine Salon <asalon@vmware.com>