### PR TITLE
Redirect to slack channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,7 @@ The Precaution project team welcomes contributions from the community. Before yo
 ## License
 
 BSD-2 License
+
+## Have any other question? 
+
+If you have any other question which was not answered in the docs or in the README, please let us know in our slack channel.


### PR DESCRIPTION
Redirects users with questions to our slack channel.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>