### PR TITLE
Readme modifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,7 @@ The Precaution project team welcomes contributions from the community. Before yo
 ## License
 
 BSD-2 License
+
+## Have any other question?
+
+If you have any other question which was not answered in the docs or in the README, please let us know in our slack channel.

--- a/README.md
+++ b/README.md
@@ -99,4 +99,4 @@ BSD-2 License
 
 ## Do you have any other question? 
 
-If you have any other question which was not answered in the docs or in the README, please let us know in our slack channel.
+If you have any other question which was not answered in the docs or in the README, please let us know in the #precaution channel on [Slack](https://code.vmware.com/web/code/join).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ which allows results to be presented directly as inline annotations instead of
 a pass/fail status report.
 
 
-Precaution currently supports analysis of python files via Bandit. New languages may be added in future.
+Precaution currently supports analysis of python files via Bandit and go files via Gosec. New languages may be added in future.
+
+* Documentation: https://vmware.github.io/precaution/
+* Source: https://github.com/vmware/precaution
+* Bugs: https://github.com/vmware/precaution/issues
 
 ## Installing Precaution on a GitHub repository
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,6 @@ The Precaution project team welcomes contributions from the community. Before yo
 
 BSD-2 License
 
-## Have any other question?
+## Do you have any other question? 
 
 If you have any other question which was not answered in the docs or in the README, please let us know in our slack channel.


### PR DESCRIPTION
As Antoine Salon mentioned we missed to add that we support go via Gosec.

Also I saw that there is no direct link to our documentation and decided to add other links as it is done in Bandit: https://github.com/PyCQA/bandit

And last I thought it will be good to show willingness for questions from the users and that is a great way to promote our slack channel.