### PR TITLE
Report generation refactoring

### DIFF
--- a/bandit/bandit_report.js
+++ b/bandit/bandit_report.js
@@ -1,7 +1,6 @@
 // Copyright 2018 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
-const { config } = require('../config')
 const { getAnnotation } = require('./bandit_annotations')
 const { countIssueLevels } = require('../annotations_levels')
 
@@ -23,23 +22,13 @@ function createMoreInfoLinks (issues) {
 }
 
 /**
- * Convert bandit output into valid 'output' object for check run conclusion
+ * Process Bandit output (generate annotations, count issue levels)
  * @param {any} results Bandit json output
  */
 module.exports = (results) => {
-  let title = ''
-  let summary = ''
-  let annotations = []
-  let moreInfo = ''
+  const annotations = results.results.map(issue => getAnnotation(issue))
+  const issueCount = countIssueLevels(annotations)
+  const moreInfo = annotations.length > 0 ? createMoreInfoLinks(results.results) : ''
 
-  if (results && results.results.length !== 0) {
-    title = config.issuesFoundResultTitle
-    annotations = results.results.map(issue => getAnnotation(issue))
-    summary = countIssueLevels(annotations)
-    moreInfo = createMoreInfoLinks(results.results)
-  } else {
-    title = config.noIssuesResultTitle
-    summary = config.noIssuesResultSummary
-  }
-  return { title, summary, annotations, moreInfo }
+  return { annotations, issueCount, moreInfo }
 }

--- a/github_api_helper.js
+++ b/github_api_helper.js
@@ -89,7 +89,7 @@ function getConclusion (annotations) {
  * Send check run results
  * @param {import('probot').Context} context Probot context
  * @param {Number} runID check run identifier
- * @param {Object} output output from the scan of Gosec and Bandit
+ * @param {Object} output merged scan output
  * @returns {Promise<any>} GitHub response
  * See: https://developer.github.com/v3/checks/runs/#update-a-check-run
  */

--- a/gosec/gosec_annotations.js
+++ b/gosec/gosec_annotations.js
@@ -11,8 +11,8 @@ const { getAnnotationLevel } = require('../annotations_levels')
  */
 function getAnnotation (issue, directory) {
   const path = issue.file.replace(directory + '/', '')
-  const startLine = issue.line
-  const endLine = issue.line
+  const startLine = Number(issue.line)
+  const endLine = startLine
   const annotationLevel = getAnnotationLevel(issue.severity, issue.confidence)
   const title = `${issue.rule_id}:${issue.details}`
   const message = `The issue is in the code: ${issue.code}`

--- a/gosec/gosec_report.js
+++ b/gosec/gosec_report.js
@@ -1,28 +1,18 @@
 // Copyright 2018 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
-const { config } = require('../config')
 const { getAnnotation } = require('./gosec_annotations')
 const { countIssueLevels } = require('../annotations_levels')
 
 /**
- *
- * @param {*} results results gosec json output
+ * Process Gosec output (generate annotations, count issue levels)
+ * @param {*} results Gosec json output
  * @param {*} directory working directory for Gosec process
  */
 module.exports = (results, directory) => {
-  let title = ''
-  let summary = ''
-  let annotations = []
+  const annotations = results.Issues.map(issue => getAnnotation(issue, directory))
+  const issueCount = countIssueLevels(annotations)
+  const moreInfo = ''
 
-  if (results && results.Issues.length !== 0) {
-    title = config.issuesFoundResultTitle
-    annotations = results.Issues.map(issue => getAnnotation(issue, directory))
-    summary = countIssueLevels(annotations)
-  } else {
-    title = config.noIssuesResultTitle
-    summary = config.noIssuesResultSummary
-  }
-
-  return { title, summary, annotations }
+  return { annotations, issueCount, moreInfo }
 }

--- a/linters/bandit.js
+++ b/linters/bandit.js
@@ -18,7 +18,7 @@ module.exports = class Bandit {
   }
 
   get defaultReport () {
-    return report(null)
+    return { annotations: [], issueCount: { errors: 0, warnings: 0, notices: 0 }, moreInfo: '' }
   }
 
   /**

--- a/linters/gosec.js
+++ b/linters/gosec.js
@@ -18,7 +18,7 @@ module.exports = class Gosec {
   }
 
   get defaultReport () {
-    return report(null)
+    return { annotations: [], issueCount: { errors: 0, warnings: 0, notices: 0 }, moreInfo: '' }
   }
 
   /**

--- a/merge_reports.js
+++ b/merge_reports.js
@@ -3,71 +3,42 @@
 
 const { config } = require('./config')
 
-/**
- * Creates the final summary message describing the number of errors, warnings and notices.
- * @param {Number} errors the number of errors found
- * @param {Number} warnings the number of warnings found
- * @param {Number} notices the number of notices found
- */
-function createFinalSummaryMessage (errors, warnings, notices) {
+const fmt = (name, count, symbol) => {
+  if (!count) {
+    return ''
+  }
+  return `:${symbol}: ${count} ${name}${count > 1 ? 's' : ''}\n`
+}
+
+const mergeSummaries = (summaries) => {
   let summary = ''
 
-  const errorsMessage = errors > 1 ? ':x: ' + errors + ' errors\n'
-    : ':x: 1 error\n'
-  const warningsMessage = warnings > 1 ? ':warning: ' + warnings + ' warnings\n'
-    : ':warning: 1 warning\n'
-  const noticesMessage = notices > 1 ? ':information_source: ' + notices + ' notices\n'
-    : ':information_source: 1 notice\n'
+  const errors = summaries.map(s => s.errors).reduce((a, b) => a + b, 0)
+  summary += fmt('error', errors, 'x')
 
-  summary += errors !== 0 ? errorsMessage : ''
-  summary += warnings !== 0 ? warningsMessage : ''
-  summary += notices !== 0 ? noticesMessage : ''
+  const warnings = summaries.map(s => s.warnings).reduce((a, b) => a + b, 0)
+  summary += fmt('warning', warnings, 'warning')
+
+  const notices = summaries.map(s => s.notices).reduce((a, b) => a + b, 0)
+  summary += fmt('notice', notices, 'information_source')
 
   return summary
 }
 
-function mergeSummaries (banditSummary, gosecSummary) {
-  let result = { errors: 0, warnings: 0, notices: 0 }
-
-  if (banditSummary === config.noIssuesResultSummary) {
-    result = gosecSummary
-  } else if (gosecSummary === config.noIssuesResultSummary) {
-    result = banditSummary
-  } else {
-    result.errors = banditSummary.errors + gosecSummary.errors
-    result.warnings = banditSummary.warnings + gosecSummary.warnings
-    result.notices = banditSummary.notices + gosecSummary.notices
-  }
-
-  return createFinalSummaryMessage(result.errors, result.warnings, result.notices)
-}
-
 /**
- * @param banditReport the Bandit output converted into valid 'output' object for check run conclusion
- * @param gosecReport the Gosec output converted into valid 'output' object for check run conclusion
- * for reference of the 'output' object see: https://developer.github.com/v3/checks/runs/#output-object
+ * @param {any[]} reports linter report objects to be merged
+ * @returns merged report ready to be sent to GitHub
+ * for object schema see: https://developer.github.com/v3/checks/runs/#output-object
  */
-module.exports = (banditReport, gosecReport) => {
-  let title = ''
-  let summary = ''
-  let text = ''
-  let annotations = []
+module.exports = (reports) => {
+  const annotations = reports.map(r => r.annotations).flat()
 
-  if (banditReport.title === config.noIssuesResultTitle && banditReport.title === gosecReport.title) {
-    title = config.noIssuesResultTitle
-    summary = config.noIssuesResultSummary
-  } else {
-    title = config.issuesFoundResultTitle
-    summary = mergeSummaries(banditReport.summary, gosecReport.summary)
-    text = banditReport.moreInfo
+  if (!annotations.length) {
+    return { title: config.noIssuesResultTitle, summary: config.noIssuesResultSummary, annotations, text: '' }
   }
 
-  if (!gosecReport.annotations) {
-    annotations = banditReport.annotations
-  } else if (!banditReport.annotations) {
-    annotations = gosecReport.annotations
-  } else {
-    annotations = annotations.concat(gosecReport.annotations, banditReport.annotations)
-  }
-  return { title, summary, annotations, text }
+  const summary = mergeSummaries(reports.map(r => r.issueCount))
+
+  // TODO: handle text merge
+  return { title: config.issuesFoundResultTitle, summary, annotations, text: '' }
 }

--- a/runner.js
+++ b/runner.js
@@ -17,10 +17,8 @@ const linters = require('./linters')
 async function runLinters (files, repoID, prID) {
   // TODO: Sync directory with file download location resolution
   const reports = Object.values(linters).map((linter) => run(linter, linter.workingDirectoryForPR(repoID, prID), files))
-  const resolved = await Promise.all(reports)
 
-  // TODO: rewrite merge to handle list of reports
-  return merge(resolved[0], resolved[1])
+  return merge(await Promise.all(reports))
 }
 
 /**

--- a/test/bandit.report.test.js
+++ b/test/bandit.report.test.js
@@ -2,14 +2,22 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 const generateReport = require('../bandit/bandit_report')
-const { config } = require('../config')
+
 const banditResults = require('./fixtures/reports/bandit_vulnerable.json')
 
-describe('Report generation', () => {
+describe('Bandit report generation', () => {
   let report
 
   beforeEach(() => {
     report = generateReport(banditResults)
+  })
+
+  test('Creates correct report structure', () => {
+    expect(report).toHaveProperty('annotations')
+    expect(report).toHaveProperty('issueCount.errors')
+    expect(report).toHaveProperty('issueCount.warnings')
+    expect(report).toHaveProperty('issueCount.notices')
+    expect(report).toHaveProperty('moreInfo')
   })
 
   test('Creates correct annotations', () => {
@@ -25,28 +33,20 @@ describe('Report generation', () => {
     })
   })
 
-  test('Creates correct report structure', () => {
-    expect(report.summary).not.toBe('')
-    expect(report).toHaveProperty('annotations')
-    expect(report).toHaveProperty('title')
+  test('Creates correct issue count', () => {
+    expect(report.issueCount.errors).toBe(1)
+    expect(report.issueCount.warnings).toBe(3)
+    expect(report.issueCount.notices).toBe(0)
   })
 
-  test('Handles empty reports', () => {
-    const report = generateReport(null)
-    expect(report).toHaveProperty('annotations')
-    expect(report).toHaveProperty('summary')
-    expect(report).toHaveProperty('title')
-  })
+  test('Handles no vuln reports', async () => {
+    const jsonResults = require('./fixtures/reports/bandit_safe.json')
 
-  // This test caches a few cases at a time: when a pr scans python files without security issues
-  // and when a PR doesn't have any python files
-  test('Generate report on results from Bandit without security issues', async () => {
-    const results = require('./fixtures/reports/bandit_safe.json')
+    const report = generateReport(jsonResults)
 
-    const report = generateReport(results)
-
-    expect(report.title).toEqual(config.noIssuesResultTitle)
-    expect(report.summary).toEqual(config.noIssuesResultSummary)
-    expect(report.annotations.length).toEqual(0)
+    expect(report.annotations).toHaveLength(0)
+    expect(report.issueCount.errors).toBe(0)
+    expect(report.issueCount.warnings).toBe(0)
+    expect(report.issueCount.notices).toBe(0)
   })
 })

--- a/test/fixtures/reports/bandit_vulnerable.json
+++ b/test/fixtures/reports/bandit_vulnerable.json
@@ -1,89 +1,89 @@
 {
-    "errors": [],
-    "generated_at": "2018-08-30T17:29:56Z",
-    "metrics": {
-      "_totals": {
-        "CONFIDENCE.HIGH": 3.0,
-        "CONFIDENCE.LOW": 1.0,
-        "CONFIDENCE.MEDIUM": 0.0,
-        "CONFIDENCE.UNDEFINED": 0.0,
-        "SEVERITY.HIGH": 1.0,
-        "SEVERITY.LOW": 0.0,
-        "SEVERITY.MEDIUM": 3.0,
-        "SEVERITY.UNDEFINED": 0.0,
-        "loc": 11,
-        "nosec": 0
-      },
-      "test/fixtures/python/mix.py": {
-        "CONFIDENCE.HIGH": 3.0,
-        "CONFIDENCE.LOW": 1.0,
-        "CONFIDENCE.MEDIUM": 0.0,
-        "CONFIDENCE.UNDEFINED": 0.0,
-        "SEVERITY.HIGH": 1.0,
-        "SEVERITY.LOW": 0.0,
-        "SEVERITY.MEDIUM": 3.0,
-        "SEVERITY.UNDEFINED": 0.0,
-        "loc": 11,
-        "nosec": 0
-      }
+  "errors": [],
+  "generated_at": "2018-08-30T17:29:56Z",
+  "metrics": {
+    "_totals": {
+      "CONFIDENCE.HIGH": 3.0,
+      "CONFIDENCE.LOW": 1.0,
+      "CONFIDENCE.MEDIUM": 0.0,
+      "CONFIDENCE.UNDEFINED": 0.0,
+      "SEVERITY.HIGH": 1.0,
+      "SEVERITY.LOW": 0.0,
+      "SEVERITY.MEDIUM": 3.0,
+      "SEVERITY.UNDEFINED": 0.0,
+      "loc": 11,
+      "nosec": 0
     },
-    "results": [
-      {
-        "code": "7                          backend=backends.default_backend())\n8 dsa.generate_private_key(key_size=1024,\n9                          backend=backends.default_backend())\n10 \n",
-        "filename": "mix.py",
-        "issue_confidence": "HIGH",
-        "issue_severity": "MEDIUM",
-        "issue_text": "DSA key sizes below 2048 bits are considered breakable. ",
-        "line_number": 8,
-        "line_range": [
-          8,
-          9
-        ],
-        "more_info": "https://bandit.readthedocs.io/en/latest/plugins/b505_weak_cryptographic_key.html",
-        "test_id": "B505",
-        "test_name": "weak_cryptographic_key"
-      },
-      {
-        "code": "10 \n11 ssl.wrap_socket(ssl_version=ssl.PROTOCOL_SSLv2)\n12 \n",
-        "filename": "mix.py",
-        "issue_confidence": "HIGH",
-        "issue_severity": "HIGH",
-        "issue_text": "ssl.wrap_socket call with insecure SSL/TLS protocol version identified, security issue.",
-        "line_number": 11,
-        "line_range": [
-          11
-        ],
-        "more_info": "https://bandit.readthedocs.io/en/latest/plugins/b502_ssl_with_bad_version.html",
-        "test_id": "B502",
-        "test_name": "ssl_with_bad_version"
-      },
-      {
-        "code": "12 \n13 mode = ECB(iv)\n14 \n",
-        "filename": "mix.py",
-        "issue_confidence": "HIGH",
-        "issue_severity": "MEDIUM",
-        "issue_text": "Use of insecure cipher mode cryptography.hazmat.primitives.ciphers.modes.ECB.",
-        "line_number": 13,
-        "line_range": [
-          13
-        ],
-        "more_info": "https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html#b304-b305-ciphers-and-modes",
-        "test_id": "B305",
-        "test_name": "blacklist"
-      },
-      {
-        "code": "14 \n15 query = \"SELECT * FROM foo WHERE id = '%s'\" % identifier\n",
-        "filename": "mix.py",
-        "issue_confidence": "LOW",
-        "issue_severity": "MEDIUM",
-        "issue_text": "Possible SQL injection vector through string-based query construction.",
-        "line_number": 15,
-        "line_range": [
-          15
-        ],
-        "more_info": "https://bandit.readthedocs.io/en/latest/plugins/b608_hardcoded_sql_expressions.html",
-        "test_id": "B608",
-        "test_name": "hardcoded_sql_expressions"
-      }
-    ]
-  }
+    "test/fixtures/python/mix.py": {
+      "CONFIDENCE.HIGH": 3.0,
+      "CONFIDENCE.LOW": 1.0,
+      "CONFIDENCE.MEDIUM": 0.0,
+      "CONFIDENCE.UNDEFINED": 0.0,
+      "SEVERITY.HIGH": 1.0,
+      "SEVERITY.LOW": 0.0,
+      "SEVERITY.MEDIUM": 3.0,
+      "SEVERITY.UNDEFINED": 0.0,
+      "loc": 11,
+      "nosec": 0
+    }
+  },
+  "results": [
+    {
+      "code": "7                          backend=backends.default_backend())\n8 dsa.generate_private_key(key_size=1024,\n9                          backend=backends.default_backend())\n10 \n",
+      "filename": "mix.py",
+      "issue_confidence": "HIGH",
+      "issue_severity": "MEDIUM",
+      "issue_text": "DSA key sizes below 2048 bits are considered breakable. ",
+      "line_number": 8,
+      "line_range": [
+        8,
+        9
+      ],
+      "more_info": "https://bandit.readthedocs.io/en/latest/plugins/b505_weak_cryptographic_key.html",
+      "test_id": "B505",
+      "test_name": "weak_cryptographic_key"
+    },
+    {
+      "code": "10 \n11 ssl.wrap_socket(ssl_version=ssl.PROTOCOL_SSLv2)\n12 \n",
+      "filename": "mix.py",
+      "issue_confidence": "HIGH",
+      "issue_severity": "HIGH",
+      "issue_text": "ssl.wrap_socket call with insecure SSL/TLS protocol version identified, security issue.",
+      "line_number": 11,
+      "line_range": [
+        11
+      ],
+      "more_info": "https://bandit.readthedocs.io/en/latest/plugins/b502_ssl_with_bad_version.html",
+      "test_id": "B502",
+      "test_name": "ssl_with_bad_version"
+    },
+    {
+      "code": "12 \n13 mode = ECB(iv)\n14 \n",
+      "filename": "mix.py",
+      "issue_confidence": "HIGH",
+      "issue_severity": "MEDIUM",
+      "issue_text": "Use of insecure cipher mode cryptography.hazmat.primitives.ciphers.modes.ECB.",
+      "line_number": 13,
+      "line_range": [
+        13
+      ],
+      "more_info": "https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html#b304-b305-ciphers-and-modes",
+      "test_id": "B305",
+      "test_name": "blacklist"
+    },
+    {
+      "code": "14 \n15 query = \"SELECT * FROM foo WHERE id = '%s'\" % identifier\n",
+      "filename": "mix.py",
+      "issue_confidence": "LOW",
+      "issue_severity": "MEDIUM",
+      "issue_text": "Possible SQL injection vector through string-based query construction.",
+      "line_number": 15,
+      "line_range": [
+        15
+      ],
+      "more_info": "https://bandit.readthedocs.io/en/latest/plugins/b608_hardcoded_sql_expressions.html",
+      "test_id": "B608",
+      "test_name": "hardcoded_sql_expressions"
+    }
+  ]
+}

--- a/test/fixtures/reports/gosec_safe.json
+++ b/test/fixtures/reports/gosec_safe.json
@@ -1,9 +1,9 @@
 {
-	"Issues": [],
-	"Stats": {
-		"files": 1,
-		"lines": 7,
-		"nosec": 0,
-		"found": 0
-	}
+  "Issues": [],
+  "Stats": {
+    "files": 1,
+    "lines": 7,
+    "nosec": 0,
+    "found": 0
+  }
 }

--- a/test/fixtures/reports/gosec_safe.json
+++ b/test/fixtures/reports/gosec_safe.json
@@ -1,0 +1,9 @@
+{
+	"Issues": [],
+	"Stats": {
+		"files": 1,
+		"lines": 7,
+		"nosec": 0,
+		"found": 0
+	}
+}

--- a/test/fixtures/reports/gosec_vulnerable.json
+++ b/test/fixtures/reports/gosec_vulnerable.json
@@ -9,7 +9,7 @@
       "code": "password := \"f62e5bcda4fae4f82370da0c6f20697b8f8447ef\"",
       "line": "16"
     },
-	{
+    {
       "severity": "MEDIUM",
       "confidence": "HIGH",
       "rule_id": "G102",
@@ -17,8 +17,8 @@
       "file": "test/fixtures/go/src/bad_files/badTestFile.go",
       "code": "net.Listen(\"tcp\", \"0.0.0.0:2000\")",
       "line": "20"
-	},
-	{
+    },
+    {
       "severity": "MEDIUM",
       "confidence": "HIGH",
       "rule_id": "G302",

--- a/test/gosec.report.test.js
+++ b/test/gosec.report.test.js
@@ -1,22 +1,52 @@
 // Copyright 2018 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
-const gosecReport = require('../gosec/gosec_report')
-const { config } = require('../config')
+const generateReport = require('../gosec/gosec_report')
 
-describe('Gosec report tests', () => {
-  test('Empty result parameter', () => {
-    const trueReport = gosecReport('', '')
-    expect(trueReport.title).toEqual(config.noIssuesResultTitle)
-    expect(trueReport.summary).toEqual(config.noIssuesResultSummary)
-    expect(trueReport.annotations.length).toEqual(0)
+const gosecResults = require('./fixtures/reports/gosec_vulnerable.json')
+
+describe('Gosec report generation', () => {
+  let report
+
+  beforeEach(() => {
+    report = generateReport(gosecResults, 'test/fixtures/go/src')
   })
 
-  test('Generate valid report', () => {
-    const mixedResults = require('./fixtures/reports/gosec_vulnerable.json')
-    const trueReport = gosecReport(mixedResults, './fixtures/reports/')
-    expect(trueReport.title).toEqual(config.issuesFoundResultTitle)
-    expect(trueReport.summary).not.toBe('')
-    expect(trueReport.annotations.length).toBeGreaterThan(0)
+  test('Creates correct report structure', () => {
+    expect(report).toHaveProperty('annotations')
+    expect(report).toHaveProperty('issueCount.errors')
+    expect(report).toHaveProperty('issueCount.warnings')
+    expect(report).toHaveProperty('issueCount.notices')
+    expect(report).toHaveProperty('moreInfo')
+  })
+
+  test('Creates correct annotations', () => {
+    expect(report.annotations).toHaveLength(6)
+    expect(report.annotations[0].end_line).toBe(16)
+    expect(report.annotations[3].start_line).toBe(28)
+    expect(report.annotations[1].path).toBe('bad_files/badTestFile.go')
+    expect(report.annotations[2].title).toEqual(expect.stringContaining('G302'))
+
+    report.annotations.forEach(annotation => {
+      expect(annotation.annotation_level).toMatch(/notice|warning|failure/)
+      expect(annotation.message).not.toBe('')
+    })
+  })
+
+  test('Creates correct issue count', () => {
+    expect(report.issueCount.errors).toBe(1)
+    expect(report.issueCount.warnings).toBe(5)
+    expect(report.issueCount.notices).toBe(0)
+  })
+
+  test('Handles no vuln reports', async () => {
+    const jsonResults = require('./fixtures/reports/gosec_safe.json')
+
+    const report = generateReport(jsonResults)
+
+    expect(report.annotations).toHaveLength(0)
+    expect(report.issueCount.errors).toBe(0)
+    expect(report.issueCount.warnings).toBe(0)
+    expect(report.issueCount.notices).toBe(0)
   })
 })

--- a/test/gosec.spawn.test.js
+++ b/test/gosec.spawn.test.js
@@ -15,10 +15,10 @@ describe('Gosec runner', () => {
     const report = await gosec('test/fixtures/go/src/vulnerable', ['bad_test_file.go'])
 
     expect(report.annotations.length).toEqual(6)
-    expect(report.annotations[0].start_line).toEqual('15')
-    expect(report.annotations[1].start_line).toEqual('19')
-    expect(report.annotations[2].start_line).toEqual('26')
-    expect(report.annotations[3].start_line).toEqual('27')
+    expect(report.annotations[0].start_line).toEqual(15)
+    expect(report.annotations[1].start_line).toEqual(19)
+    expect(report.annotations[2].start_line).toEqual(26)
+    expect(report.annotations[3].start_line).toEqual(27)
   })
 
   test('Passes on safe file', async () => {
@@ -31,8 +31,8 @@ describe('Gosec runner', () => {
     const report = await gosec('test/fixtures/go/src/vulnerable_package/', ['bad_test_file.go', 'networking_binding.go', 'randNumTest.go'])
 
     expect(report.annotations.length).toEqual(8)
-    expect(report.annotations[4].start_line).toEqual('9')
-    expect(report.annotations[7].start_line).toEqual('16')
+    expect(report.annotations[4].start_line).toEqual(9)
+    expect(report.annotations[7].start_line).toEqual(16)
   })
 
   test('Handles empty input', async () => {

--- a/test/merge.reports.test.js
+++ b/test/merge.reports.test.js
@@ -1,65 +1,70 @@
 // Copyright 2018 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
-const { config } = require('../config')
 const mergeReports = require('../merge_reports')
+
+const { config } = require('../config')
 const banditAnnotations = require('./fixtures/annotations/mixed_levels_annotations.json').annotations
 const gosecAnnotations = require('./fixtures/annotations/gosec_mix_annotations.json').annotations
 
-const banditSummary = { errors: 1, warnings: 1, notices: 1 }
-const gosecSummary = { errors: 1, warnings: 1, notices: 0 }
+const noIssues = { errors: 0, warnings: 0, notices: 0 }
+const someIssues = { errors: 1, warnings: 4, notices: 2 }
+const moreIssues = { errors: 4, warnings: 3, notices: 0 }
+
+const report = (issueCount, annotations) => {
+  return { annotations, issueCount, moreInfo: '' }
+}
 
 describe('Merge reports tests from Bandit and Gosec reports', () => {
-  test('No issues found from both Gosec and Bandit', () => {
-    const banditReport = { title: config.noIssuesResultTitle, summary: config.noIssuesResultSummary, annotations: [] }
-    const gosecReport = { title: config.noIssuesResultTitle, summary: config.noIssuesResultSummary, annotations: [] }
+  test('No issues', () => {
+    const banditReport = report(noIssues, [])
+    const gosecReport = report(noIssues, [])
 
-    const result = mergeReports(banditReport, gosecReport)
+    const result = mergeReports([banditReport, gosecReport])
     expect(result.title).toEqual(config.noIssuesResultTitle)
     expect(result.summary).toEqual(config.noIssuesResultSummary)
+    expect(result.annotations).toHaveLength(0)
   })
 
-  test('Issues found by Bandit and no issues found by Gosec', () => {
-    const banditReport = { title: config.issuesFoundResultTitle, summary: banditSummary, annotations: banditAnnotations }
-    const gosecReport = { title: config.noIssuesResultTitle, summary: config.noIssuesResultSummary, annotations: [] }
+  test('Bandit issues', () => {
+    // We don't need the issue count to correspond to the actual annotations (code handles them separately)
+    const banditReport = report(someIssues, banditAnnotations)
+    const gosecReport = report(noIssues, [])
 
     const expectedSummary = ':x: 1 error\n' +
-      ':warning: 1 warning\n' +
-      ':information_source: 1 notice\n'
+      ':warning: 4 warnings\n' +
+      ':information_source: 2 notices\n'
 
-    const result = mergeReports(banditReport, gosecReport)
+    const result = mergeReports([banditReport, gosecReport])
     expect(result.title).toEqual(config.issuesFoundResultTitle)
     expect(result.summary).toEqual(expectedSummary)
     expect(result.annotations).toEqual(banditAnnotations)
   })
 
-  test('No issues found by Bandit but issues are found by Gosec', () => {
-    const banditReport = { title: config.noIssuesResultTitle, summary: config.noIssuesResultSummary, annotations: [] }
-    const gosecReport = { title: config.issuesFoundResultTitle, summary: gosecSummary, annotations: gosecAnnotations }
+  test('Gosec issues', () => {
+    const banditReport = report(noIssues, [])
+    const gosecReport = report(moreIssues, gosecAnnotations)
 
-    const expectedSummary = ':x: 1 error\n' +
-      ':warning: 1 warning\n'
+    const expectedSummary = ':x: 4 errors\n' +
+      ':warning: 3 warnings\n'
 
-    const result = mergeReports(banditReport, gosecReport)
+    const result = mergeReports([banditReport, gosecReport])
     expect(result.title).toEqual(config.issuesFoundResultTitle)
     expect(result.summary).toEqual(expectedSummary)
     expect(result.annotations).toEqual(gosecAnnotations)
   })
 
-  test('Issues found by Bandit and by Gosec', () => {
-    const banditReport = { title: config.issuesFoundResultTitle, summary: banditSummary, annotations: banditAnnotations }
-    const gosecReport = { title: config.issuesFoundResultTitle, summary: gosecSummary, annotations: gosecAnnotations }
+  test('Both issues', () => {
+    const banditReport = report(someIssues, banditAnnotations)
+    const gosecReport = report(moreIssues, gosecAnnotations)
 
-    const expectedSummary = ':x: 2 errors\n' +
-      ':warning: 2 warnings\n' +
-      ':information_source: 1 notice\n'
+    const expectedSummary = ':x: 5 errors\n' +
+      ':warning: 7 warnings\n' +
+      ':information_source: 2 notices\n'
 
-    let expectedAnnotations = []
-    expectedAnnotations = expectedAnnotations.concat(gosecAnnotations, banditAnnotations)
-
-    const result = mergeReports(banditReport, gosecReport)
+    const result = mergeReports([banditReport, gosecReport])
     expect(result.title).toEqual(config.issuesFoundResultTitle)
     expect(result.summary).toEqual(expectedSummary)
-    expect(result.annotations).toEqual(expectedAnnotations)
+    expect(result.annotations).toHaveLength(5)
   })
 })


### PR DESCRIPTION
This PR sits on top of #78.

Enforce a consistent schema for linter reports, move presentation logic to merge_reports and counting issue levels to linter report generation.

Report merging now handles an arbitrary number of reports.