### PR TITLE
Reduce tested node versions to just 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ script:
 
 language: node_js
 node_js:
-  - "8"
-  - "10"
   - "11"
 
 addons:

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "standard": "^12.0.1"
   },
   "engines": {
-    "node": ">= 8.3"
+    "node": ">= 11"
   },
   "jest": {
     "testEnvironment": "node",


### PR DESCRIPTION
As a service, we don't really need to support multiple node versions.
Therefore, this change limits our testing and support to just Node.js
11.

Signed-off-by: Eric Brown <browne@vmware.com>