### PR TITLE
Fix for "across the forks" PRs problems

### DIFF
--- a/github_api_helper.js
+++ b/github_api_helper.js
@@ -46,20 +46,20 @@ function getPRFiles (context, number) {
 /**
  * Get file contents as raw data
  * @param {import('probot').Context} context Probot context
- *  @param {any[]} pullRequests object which contains information about the pull request
  * @param {string} path file path relative to repository root
  * @param {string} ref sha of file revision
+ * @param {pull_request.head?} head Reference to the fork the commit originated from
  * @returns {Promise<any>} GitHub response
  * See https://developer.github.com/v3/repos/contents/#get-contents
  */
-function getRawFileContents (context, pullRequest, path, ref) {
+function getRawFileContents (context, path, ref, head) {
   let { owner, repo } = context.repo()
   // This check is necessary in the case when there is a pr
   // which is not from forked repository.
-  // Then the repo and owner fields are not in the pullRequest object
-  if (pullRequest.head.user) {
-    owner = pullRequest.head.user.login
-    repo = pullRequest.head.repo.name
+  // Then the repo and owner fields are not in the head object
+  if (head.user) {
+    owner = head.user.login
+    repo = head.repo.name
   }
 
   return context.github.repos.getContents({

--- a/index.js
+++ b/index.js
@@ -44,18 +44,17 @@ module.exports = app => {
     }
   })
 
-  app.on(['pull_request.opened', 'pull_request.reopened'], async context => {
+  app.on(['pull_request.opened', 'pull_request.reopened', 'pull_request.synchronize'], async context => {
     // Same thing but have to intercept the event because check suite is not triggered
     const pullRequest = context.payload.pull_request
     const headSha = pullRequest.head.sha
-
     await runLinterFromPRData([pullRequest], context, headSha)
   })
 }
 
 /**
  * Retrieve files modified by pull request(s), run linter and send results
- * @param {any[]} pullRequests
+ * @param {any[]} pullRequests object which contains information about the pull request
  * @param {import('probot').Context} context
  * @param {string} headSha
  */
@@ -111,7 +110,7 @@ async function processPullRequest (pullRequest, context) {
     .map(async fileJSON => {
       const filename = fileJSON.filename
 
-      const headRevision = apiHelper.getContents(context, filename, ref)
+      const headRevision = apiHelper.getContents(context, pullRequest, filename, ref)
 
       // TODO: merge this code with linter-specific path resolution
       if (filename.endsWith('.py')) {

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ async function processPullRequest (pullRequest, context) {
     .map(async fileJSON => {
       const filename = fileJSON.filename
 
-      const headRevision = apiHelper.getContents(context, pullRequest, filename, ref)
+      const headRevision = apiHelper.getContents(context, filename, ref, pullRequest.head)
 
       // TODO: merge this code with linter-specific path resolution
       if (filename.endsWith('.py')) {


### PR DESCRIPTION
Close: https://github.com/vmware/precaution/issues/111

One of the bugs is when you make a pull request across forks. There was an error because it searched the files from the pr in the base repository instead of the forked repository.

The second bug is when there is a pull request across forks and then when you add commit to an existing pull request we didn't catch the
pull_request.synchronize event and then Precaution will queued for ever:
![image](https://user-images.githubusercontent.com/16246778/51403252-97d68080-1b58-11e9-8f21-178a7ee68879.png)

NOTE: The "Re-run" button doesn't work when there is pr across forks. The problem is that GitHub API give to Precaution an empty pull request object... I think this is a bug in the GitHub API and I will contact with them.

I wanted to publish this PR as fast as I could and that is why I didn't add unit tests for across the forks PRs.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>