### PR TITLE
Add integration test for success conclusion

### DIFF
--- a/test/fixtures/pull_request.files.safe.json
+++ b/test/fixtures/pull_request.files.safe.json
@@ -1,0 +1,12 @@
+{
+  "data": [
+    {
+      "filename": "mix.safe.py",
+      "status": "added"
+    },
+    {
+      "filename": "hello.go",
+      "status": "added"
+    }
+  ]
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,8 +11,9 @@ const checkSuiteRerequestedEvent = require('./events/check_suite.rerequested.jso
 const checkRunRerequestEvent = require('./events/check_run_rerequested.json')
 const pullRequestOpenedEvent = require('./events/pull_request.opened.json')
 
-const samplePythonPRFixture = require('./fixtures/pull_request.files.python.json')
 const sampleMixedPRFixture = require('./fixtures/pull_request.files.mix.json')
+const samplePythonPRFixture = require('./fixtures/pull_request.files.python.json')
+const sampleSafePRFixture = require('./fixtures/pull_request.files.safe.json')
 
 function mockPRContents (github, PR) {
   github.pullRequests.listFiles = jest.fn().mockResolvedValue(PR)
@@ -28,6 +29,11 @@ describe('Bandit-linter', () => {
     files.forEach((filename) => {
       mockFiles[filename] = fs.readFileSync(path.join('test/fixtures/python', filename), 'utf8')
     })
+
+    // Manually load in the go file contents
+    mockFiles['networking_binding.go'] = fs.readFileSync('test/fixtures/go/src/vulnerable_package/networking_binding.go', 'utf8')
+    mockFiles['bad_test_file.go'] = fs.readFileSync('test/fixtures/go/src/vulnerable_package/bad_test_file.go', 'utf8')
+    mockFiles['hello.go'] = fs.readFileSync('test/fixtures/go/src/safe/hello_world.go', 'utf8')
   })
 
   beforeEach(() => {
@@ -142,10 +148,6 @@ describe('Bandit-linter', () => {
     })
 
     test('handles PRs with mixed file types', async () => {
-      // Manually load in the go file contents
-      mockFiles['networking_binding.go'] = fs.readFileSync('test/fixtures/go/src/vulnerable_package/networking_binding.go', 'utf8')
-      mockFiles['bad_test_file.go'] = fs.readFileSync('test/fixtures/go/src/vulnerable_package/bad_test_file.go', 'utf8')
-
       mockPRContents(github, sampleMixedPRFixture)
 
       await app.receive(pullRequestOpenedEvent)
@@ -168,6 +170,17 @@ describe('Bandit-linter', () => {
       await app.receive(checkSuiteRerequestedEvent)
 
       expect(fs.existsSync('cache/54321/2108')).toBeFalsy()
+    })
+
+    test('sends a success status on safe code', async () => {
+      mockPRContents(github, sampleSafePRFixture)
+
+      await app.receive(pullRequestOpenedEvent)
+
+      expect(github.checks.update).toHaveBeenCalledWith(expect.objectContaining({
+        status: 'completed',
+        conclusion: 'success'
+      }))
     })
 
     test('sends an error report on crash', async () => {


### PR DESCRIPTION
This should make it easier to spot issues with runs returning an error for the wrong reasons (problems with the environment or crashes).

Signed-off-by: Antoine Salon <asalon@vmware.com>