### PR TITLE
Add false-positives documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ and communicate with the checks API.
 
 ## Additional documentation
 
+- [False positives and how to handle them](docs/false_pos.md)
 - [Setting up a manual deployment](docs/manual_deployment.md)
 - [Debugging with VSCode](docs/localdev.md)
 - [Architecture](docs/architecture.md)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ and communicate with the checks API.
 
 ## Additional documentation
 
-- [False positives and how to handle them](docs/false_pos.md)
+- [False positives and how to handle them](docs/false-pos.md)
 - [Setting up a manual deployment](docs/manual_deployment.md)
 - [Debugging with VSCode](docs/localdev.md)
 - [Architecture](docs/architecture.md)

--- a/docs/false-pos.md
+++ b/docs/false-pos.md
@@ -3,7 +3,7 @@
 
 As with all automated detection tools there will be cases of false positives.
 
-The way to handle this situation is to write #nosec in your code
+If Precaution reports a failure that has been manually verified as being safe, it is possible to annotate the code with a `#nosec` comment.
 
 Here are examples:
 

--- a/docs/false-pos.md
+++ b/docs/false-pos.md
@@ -13,6 +13,10 @@ Although this line may cause a potential security issue, it will not be reported
 
 ``` self.process = subprocess.Popen('/bin/echo', shell=True)  # nosec ```
 
+
+If you want to read more about annotating the code:
+https://github.com/PyCQA/bandit#exclusions
+
 ## Go example
 
 In Go the annotation has to be inside a line or block comment:
@@ -32,3 +36,6 @@ func main(){
 }
 
 ```
+
+If you want to read more about annotating the code:
+https://github.com/securego/gosec#annotating-code

--- a/docs/false-pos.md
+++ b/docs/false-pos.md
@@ -1,0 +1,34 @@
+
+# False positives and how to handle them
+
+No tool is perfect, neither is Precaution and false positives may happened.
+
+The way to handle this situation is to write #nosec in your code
+
+Here are examples:
+
+## Python example
+
+Although this line may cause a potential security issue, it will not be reported:
+
+``` self.process = subprocess.Popen('/bin/echo', shell=True)  # nosec ```
+
+## Go example
+
+Same here, with #nosec comment you basically say: "I know what I am doing don't warn me":
+
+```go
+
+import "md5" // #nosec
+
+
+func main(){
+
+    /* #nosec */
+    if x > y {
+        h := md5.New() // this will also be ignored
+    }
+
+}
+
+```

--- a/docs/false-pos.md
+++ b/docs/false-pos.md
@@ -15,7 +15,7 @@ Although this line may cause a potential security issue, it will not be reported
 
 ## Go example
 
-Same here, with #nosec comment you basically say: "I know what I am doing don't warn me":
+In Go the annotation has to be inside a line or block comment:
 
 ```go
 

--- a/docs/false-pos.md
+++ b/docs/false-pos.md
@@ -1,7 +1,7 @@
 
 # False positives and how to handle them
 
-No tool is perfect, neither is Precaution and false positives may happened.
+As with all automated detection tools there will be cases of false positives.
 
 The way to handle this situation is to write #nosec in your code
 


### PR DESCRIPTION
Closes: https://github.com/vmware/precaution/issues/118

I was thinking that it would be a good idea to give information for the users how to handle false positives.

On another hand that means that non secure code may be introduced into the main master branch because the pull reuqest author may use this feature incorrectly.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>