### PR TITLE
Return reference links in the output

### DIFF
--- a/merge_reports.js
+++ b/merge_reports.js
@@ -39,6 +39,6 @@ module.exports = (reports) => {
 
   const summary = mergeSummaries(reports.map(r => r.issueCount))
 
-  // TODO: handle text merge
-  return { title: config.issuesFoundResultTitle, summary, annotations, text: '' }
+  const text = reports.map(r => r.moreInfo).reduce((a, b) => a + b, '')
+  return { title: config.issuesFoundResultTitle, summary, annotations, text }
 }


### PR DESCRIPTION
After the refactoring of the code we forgot to return the reference links to the documentation to the problems.

The report was like that:
![image](https://user-images.githubusercontent.com/16246778/51788533-9e33b080-2187-11e9-9a78-787cadf1fa29.png)

After merge of this pr it will be:
![image](https://user-images.githubusercontent.com/16246778/51788541-b1df1700-2187-11e9-9012-8537dc4ed810.png)

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>