### PR TITLE
Broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ and communicate with the checks API.
 
 ## Additional documentation
 
-- [False positives and how to handle them](https://vmware.github.io/precaution/docs/false-pos.html)
+- [False positives and how to handle them](https://vmware.github.io/precaution/docs/false_positivies.html)
 - [Setting up a manual deployment](https://vmware.github.io/precaution/docs/manual_deployment)
-- [Debugging with VSCode](https://vmware.github.io/precaution/docs/localdev.html)
+- [Debugging with VSCode](https://vmware.github.io/precaution/docs/local_development.html)
 - [Architecture](https://vmware.github.io/precaution/docs/architecture.html)
 
 ## Contributing


### PR DESCRIPTION
Recent PR that merged renamed the files, but the references to those docs were missed.