### PR TITLE
Use one folder for Gosec and Bandit

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -8,16 +8,9 @@ const path = require('path')
  * Get the cache path for this PR branch tag
  * @param {number} repoID repository identifier
  * @param {number} prID pull request identifier
- * @param {string} app Optional: an app that calls the function. (default bandit)
- * It's needed because gosec uses GOPATH.
  */
-function getBranchPath (repoID, prID, app) {
-  app = app || 'bandit'
-  if (app === 'bandit') {
-    return path.join('cache', repoID.toString(), prID.toString())
-  } else if (app === 'gosec') {
-    return path.join('cache/go/src', repoID.toString(), prID.toString())
-  }
+function getBranchPath (repoID, prID) {
+  return path.join('cache/go/src', repoID.toString(), prID.toString())
 }
 
 /**
@@ -26,13 +19,9 @@ function getBranchPath (repoID, prID, app) {
  * @param {number} prID unique pull request identifier
  * @param {string} filePath relative file path
  * @param {any} data file data
- * @param {string} fileType Optional: file type so it knows where to save the file (default python)
- * It's needed because go files should be in the GOPATH.
  */
-function saveFileToPRCache (repoID, prID, filePath, data, fileType) {
-  fileType = fileType || 'python'
-  const appTag = (fileType === 'go') ? 'gosec' : 'bandit'
-  const dir = getBranchPath(repoID, prID, appTag)
+function saveFileToPRCache (repoID, prID, filePath, data) {
+  const dir = getBranchPath(repoID, prID)
   writeFileCreateDirs(path.join(dir, filePath), data)
 }
 
@@ -42,8 +31,8 @@ function saveFileToPRCache (repoID, prID, filePath, data, fileType) {
  * @param {number} prID pull request identifier
  */
 function clearPRCache (repoID, prID) {
-  fs.removeSync(getBranchPath(repoID, prID, 'bandit'))
-  fs.removeSync(getBranchPath(repoID, prID, 'gosec'))
+  fs.removeSync(getBranchPath(repoID, prID))
+  fs.removeSync(getBranchPath(repoID, prID))
 }
 
 /**

--- a/linters/bandit.js
+++ b/linters/bandit.js
@@ -36,7 +36,7 @@ module.exports = class Bandit {
    * @param {string} prID PR id in repository
    */
   workingDirectoryForPR (repoID, prID) {
-    return cache.getBranchPath(repoID, prID, 'bandit')
+    return cache.getBranchPath(repoID, prID)
   }
 
   /**

--- a/linters/gosec.js
+++ b/linters/gosec.js
@@ -36,7 +36,7 @@ module.exports = class Gosec {
    * @param {string} prID PR id in repository
    */
   workingDirectoryForPR (repoID, prID) {
-    return cache.getBranchPath(repoID, prID, 'gosec')
+    return cache.getBranchPath(repoID, prID)
   }
 
   /**


### PR DESCRIPTION
We tried before to use one folder - cache/ after we figure out there that we can't because Gosec needs a full GOPATH. We stuck with using two folders cache/ for Python and cache/go/src for Go files.

I and Antoine had discussed before that we can use one folder for both Bandit and Gosec but it would be cache/go/src.
I tried this and it worked. I removed all clutter code connecting with deciding which folder to use.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>