### PR TITLE
Add info about private repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ a pass/fail status report.
 
 Precaution currently supports analysis of python files via Bandit and go files via Gosec. New languages may be added in future.
 
+Precaution can be used on Open Source and private repositories as well.
+
 * Documentation: https://vmware.github.io/precaution/
 * Source: https://github.com/vmware/precaution
 * Bugs: https://github.com/vmware/precaution/issues


### PR DESCRIPTION
I tested can we use Precaution on private repositories and the great news is that we can do it even without adding even a line of code!

I think that is worth mentioning in the README.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>