### PR TITLE
Add ESlint plugin security report files and tests

### DIFF
--- a/eslint_plugin/eslint_plugin_annotations.js
+++ b/eslint_plugin/eslint_plugin_annotations.js
@@ -5,7 +5,7 @@
  * @param {*} filePath path to the file containing the issue
  * @param {*} issue
  * @return {Object} returns an annotation object as specified here:
- * https://developer.github.com/v3/checks/runs/#annotations-object
+ * @see {@link https://developer.github.com/v3/checks/runs/#annotations-object }
  */
 function setupSingleAnnotation (filePath, issue) {
   const path = filePath
@@ -32,7 +32,7 @@ function setupSingleAnnotation (filePath, issue) {
 /**
  * @param {Object} fileWithIssues object containing all the issues for a given file
  * @return {Object[]} returns an array of annotation objects as specified here:
- * https://developer.github.com/v3/checks/runs/#annotations-object
+ * @see {@link https://developer.github.com/v3/checks/runs/#annotations-object }
  */
 function getAnnotations (fileWithIssues) {
   let annotations = []

--- a/eslint_plugin/eslint_plugin_annotations.js
+++ b/eslint_plugin/eslint_plugin_annotations.js
@@ -1,0 +1,46 @@
+// Copyright 2019 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+/**
+ * @param {*} filePath path to the file containing the issue
+ * @param {*} issue
+ * @return {Object} returns an annotation object as specified here:
+ * https://developer.github.com/v3/checks/runs/#annotations-object
+ */
+function setupSingleAnnotation (filePath, issue) {
+  const path = filePath
+  const startLine = issue.line
+  const endLine = issue.endLine
+  let annotationLevel = 'notice'
+  if (issue.severity === 1) {
+    annotationLevel = 'warning'
+  } else if (issue.severity === 2) {
+    annotationLevel = 'failure'
+  }
+  const title = issue.ruleId
+  const message = issue.message
+  return {
+    path,
+    start_line: startLine,
+    end_line: endLine,
+    annotation_level: annotationLevel,
+    title,
+    message
+  }
+}
+
+/**
+ * @param {Object} fileWithIssues object containing all the issues for a given file
+ * @return {Object[]} returns an array of annotation objects as specified here:
+ * https://developer.github.com/v3/checks/runs/#annotations-object
+ */
+function getAnnotations (fileWithIssues) {
+  let annotations = []
+  for (let i = 0; i < fileWithIssues.messages.length; ++i) {
+    const issue = fileWithIssues.messages[i]
+    annotations.push(setupSingleAnnotation(fileWithIssues.filePath, issue))
+  }
+  return annotations
+}
+
+module.exports.getAnnotations = getAnnotations

--- a/eslint_plugin/eslint_plugin_report.js
+++ b/eslint_plugin/eslint_plugin_report.js
@@ -6,13 +6,13 @@ const { countIssueLevels } = require('../annotations_levels')
 
 /**
  * Process Eslint plugin output (generate annotations, count issue levels)
- * @param {*} results Eslint plugin json output
+ * @param {*} results Eslint plugin JSON output
  */
 module.exports = (results) => {
   // The structure of the ESlint JSON output is that
   // the issues found by ESLint are grouped by files.
-  // In the ESlint output there are files without any problems
-  // and that's why I have to filter them.
+  // In the ESlint output, there are files without any problems
+  // and that's why filtration is needed.
   const filesWithIssues = results.filter((fileWithIssues) => fileWithIssues.messages.length !== 0)
   let annotations = []
   for (let i = 0; i < filesWithIssues.length; ++i) {

--- a/eslint_plugin/eslint_plugin_report.js
+++ b/eslint_plugin/eslint_plugin_report.js
@@ -1,0 +1,25 @@
+// Copyright 2019 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+const { getAnnotations } = require('./eslint_plugin_annotations')
+const { countIssueLevels } = require('../annotations_levels')
+
+/**
+ * Process Eslint plugin output (generate annotations, count issue levels)
+ * @param {*} results Eslint plugin json output
+ */
+module.exports = (results) => {
+  // The structure of the ESlint JSON output is that the issues are grouped by files.
+  // Also, the ESlint plugin gives output for every single file even though some of the files
+  // can be secure and we have to filter those files.
+  const filesWithIssues = results.filter((fileWithIssues) => fileWithIssues.messages.length !== 0)
+  let annotations = []
+  for (let i = 0; i < filesWithIssues.length; ++i) {
+    annotations = annotations.concat(getAnnotations(filesWithIssues[i]))
+  }
+
+  const issueCount = countIssueLevels(annotations)
+  const moreInfo = ''
+
+  return { annotations, issueCount, moreInfo }
+}

--- a/eslint_plugin/eslint_plugin_report.js
+++ b/eslint_plugin/eslint_plugin_report.js
@@ -9,9 +9,10 @@ const { countIssueLevels } = require('../annotations_levels')
  * @param {*} results Eslint plugin json output
  */
 module.exports = (results) => {
-  // The structure of the ESlint JSON output is that the issues are grouped by files.
-  // Also, the ESlint plugin gives output for every single file even though some of the files
-  // can be secure and we have to filter those files.
+  // The structure of the ESlint JSON output is that
+  // the issues found by ESLint are grouped by files.
+  // In the ESlint output there are files without any problems
+  // and that's why I have to filter them.
   const filesWithIssues = results.filter((fileWithIssues) => fileWithIssues.messages.length !== 0)
   let annotations = []
   for (let i = 0; i < filesWithIssues.length; ++i) {

--- a/test/eslint.plugin.report.test.js
+++ b/test/eslint.plugin.report.test.js
@@ -1,15 +1,15 @@
-// Copyright 2018 VMware, Inc.
+// Copyright 2019 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
-const generateReport = require('../bandit/bandit_report')
+const generateReport = require('../eslint_plugin/eslint_plugin_report')
 
-const banditResults = require('./fixtures/reports/bandit_vulnerable.json')
+const eslintResults = require('./fixtures/reports/eslint_vulnerable.json')
 
-describe('Bandit report generation', () => {
+describe('ESlint plugin report generation', () => {
   let report
 
   beforeEach(() => {
-    report = generateReport(banditResults)
+    report = generateReport(eslintResults, 'test/fixtures/go/src')
   })
 
   test('Creates correct report structure', () => {
@@ -22,10 +22,9 @@ describe('Bandit report generation', () => {
 
   test('Creates correct annotations', () => {
     expect(report.annotations).toHaveLength(4)
-    expect(report.annotations[0].end_line).toBe(8)
-    expect(report.annotations[3].start_line).toBe(15)
-    expect(report.annotations[1].path).toBe('mix.py')
-    expect(report.annotations[2].title).toBe('B305:blacklist')
+    expect(report.annotations[0].end_line).toBe(56)
+    expect(report.annotations[2].start_line).toBe(31)
+    expect(report.annotations[1].path).toEqual('precaution/test/index.test.js')
 
     report.annotations.forEach(annotation => {
       expect(annotation.annotation_level).toMatch(/notice|warning|failure/)
@@ -34,13 +33,13 @@ describe('Bandit report generation', () => {
   })
 
   test('Creates correct issue count', () => {
-    expect(report.issueCount.errors).toBe(1)
-    expect(report.issueCount.warnings).toBe(3)
+    expect(report.issueCount.errors).toBe(0)
+    expect(report.issueCount.warnings).toBe(4)
     expect(report.issueCount.notices).toBe(0)
   })
 
-  test('Handles no vulnerable reports', async () => {
-    const jsonResults = require('./fixtures/reports/bandit_safe.json')
+  test('Handles no vulnerable reports', () => {
+    const jsonResults = require('./fixtures/reports/eslint_safe.json')
 
     const report = generateReport(jsonResults)
 

--- a/test/fixtures/reports/eslint_safe.json
+++ b/test/fixtures/reports/eslint_safe.json
@@ -1,0 +1,26 @@
+[
+  {  
+    "filePath":"precaution/index.js",
+    "messages":[],
+    "errorCount":0,
+    "warningCount":0,
+    "fixableErrorCount":0,
+    "fixableWarningCount":0
+  },
+  {  
+    "filePath":"precaution/gosec/gosec_report.js",
+    "messages":[],
+    "errorCount":0,
+    "warningCount":0,
+    "fixableErrorCount":0,
+    "fixableWarningCount":0
+  },
+  {
+    "filePath":"precaution/bandit/bandit_report.js",
+    "messages":[],
+    "errorCount":0,
+    "warningCount":0,
+    "fixableErrorCount":0,
+    "fixableWarningCount":0
+  }
+]

--- a/test/fixtures/reports/eslint_vulnerable.json
+++ b/test/fixtures/reports/eslint_vulnerable.json
@@ -1,0 +1,68 @@
+[  
+  {  
+    "filePath":"precaution/cache.js",
+    "messages":[ 
+      {  
+        "ruleId":"security/detect-non-literal-fs-filename",
+        "severity":1,
+        "message":"Found fs.writeFileSync with non literal argument at index 0",
+        "line":56,
+        "column":3,
+        "nodeType":"MemberExpression",
+        "endLine":56,
+        "endColumn":19
+      }
+    ],
+    "errorCount":0,
+    "warningCount":1,
+    "fixableErrorCount":0,
+    "fixableWarningCount":0
+  },
+  {  
+    "filePath":"precaution/index.js",
+    "messages":[],
+    "errorCount":0,
+    "warningCount":0,
+    "fixableErrorCount":0,
+    "fixableWarningCount":0
+  },
+  {  
+    "filePath":"precaution/test/index.test.js",
+    "messages":[  
+      {  
+        "ruleId":"security/detect-object-injection",
+        "severity":1,
+        "message":"Generic Object Injection Sink",
+        "line":31,
+        "column":7,
+        "nodeType":"MemberExpression",
+        "endLine":31,
+        "endColumn":26
+      },
+      {  
+        "ruleId":"security/detect-non-literal-fs-filename",
+        "severity":1,
+        "message":"Found fs.readFileSync with non literal argument at index 0",
+        "line":31,
+        "column":29,
+        "nodeType":"MemberExpression",
+        "endLine":31,
+        "endColumn":44
+      },
+      {  
+        "ruleId":"security/detect-object-injection",
+        "severity":1,
+        "message":"Generic Object Injection Sink",
+        "line":56,
+        "column":44,
+        "nodeType":"MemberExpression",
+        "endLine":56,
+        "endColumn":59
+      }
+    ],
+    "errorCount":0,
+    "warningCount":3,
+    "fixableErrorCount":0,
+    "fixableWarningCount":0
+  }
+]

--- a/test/gosec.report.test.js
+++ b/test/gosec.report.test.js
@@ -39,7 +39,7 @@ describe('Gosec report generation', () => {
     expect(report.issueCount.notices).toBe(0)
   })
 
-  test('Handles no vuln reports', async () => {
+  test('Handles no vulnerable reports', async () => {
     const jsonResults = require('./fixtures/reports/gosec_safe.json')
 
     const report = generateReport(jsonResults)


### PR DESCRIPTION
Part of the work outlined in the enhancement issue: https://github.com/vmware/precaution/issues/137

I added the report generation of the ESlint plugin output. 

Also, I added unit tests for the ESlint report generation and two JSON files for tests.

Additionally, I fixed two typos in test/gosec.report.test.js and test/bandit.report.test.js.

There will be at least two more pull requests for ESlint plugin security - one for the actual spawn of the plugin and the second one with a .eslintrc file for the ESlint configuration and with modification in package.json adding ESlint and the plugin itself as dependencies.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>