### PR TITLE
Fix the documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ and communicate with the checks API.
 
 ## Additional documentation
 
-- [Initial setup](https://vmware.github.io/precaution/docs/initial_setup.html)
-- [False positives and how to handle them](https://vmware.github.io/precaution/docs/false_positivies.html)
-- [Setting up a manual deployment](https://vmware.github.io/precaution/docs/manual_deployment.html)
-- [Debugging with VSCode](https://vmware.github.io/precaution/docs/local_development.html)
-- [Architecture](https://vmware.github.io/precaution/docs/architecture.html)
+- [Initial setup](https://vmware.github.io/precaution/initial_setup.html)
+- [False positives and how to handle them](https://vmware.github.io/precaution/false_positivies.html)
+- [Setting up a manual deployment](https://vmware.github.io/precaution/manual_deployment.html)
+- [Debugging with VSCode](https://vmware.github.io/precaution/local_development.html)
+- [Architecture](https://vmware.github.io/precaution/architecture.html)
 
 ## Contributing
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,8 +28,8 @@ Precaution currently supports analysis of python files via Bandit and go files v
 
 ## Additional documentation
 
-- [Initial setup](https://vmware.github.io/precaution/docs/initial_setup.html)
-- [False positives and how to handle them](https://vmware.github.io/precaution/docs/false_positivies.html)
-- [Setting up a manual deployment](https://vmware.github.io/precaution/docs/manual_deployment.html)
-- [Debugging with VSCode](https://vmware.github.io/precaution/docs/local_development.html)
-- [Architecture](https://vmware.github.io/precaution/docs/architecture.html)
+- [Initial setup](https://vmware.github.io/precaution/initial_setup.html)
+- [False positives and how to handle them](https://vmware.github.io/precaution/false_positivies.html)
+- [Setting up a manual deployment](https://vmware.github.io/precaution/manual_deployment.html)
+- [Debugging with VSCode](https://vmware.github.io/precaution/local_development.html)
+- [Architecture](https://vmware.github.io/precaution/architecture.html)


### PR DESCRIPTION
Seems the there shouldn't be a "docs" path in the URL

Fixes #141 