### PR TITLE
Fix Gosec annotation

### DIFF
--- a/linters/bandit.js
+++ b/linters/bandit.js
@@ -60,6 +60,7 @@ module.exports = class Bandit {
    * Generates a report in the format expected by GitHub checks
    * from the linter results
    * @param {any} results Linter results
+   * @param {any} directory current working directory
    * @returns GitHub checks report
    */
   generateReport (results) {

--- a/linters/bandit.js
+++ b/linters/bandit.js
@@ -63,7 +63,7 @@ module.exports = class Bandit {
    * @param {any} directory current working directory
    * @returns GitHub checks report
    */
-  generateReport (results) {
+  generateReport (results, directory) {
     return report(results)
   }
 }

--- a/linters/gosec.js
+++ b/linters/gosec.js
@@ -60,9 +60,10 @@ module.exports = class Gosec {
    * Generates a report in the format expected by GitHub checks
    * from the linter results
    * @param {any} results Linter results
+   * @param {any} directory current working directory
    * @returns GitHub checks report
    */
-  generateReport (results) {
-    return report(results)
+  generateReport (results, directory) {
+    return report(results, directory)
   }
 }

--- a/runner.js
+++ b/runner.js
@@ -33,6 +33,7 @@ function run (linter, workingDirectory, files) {
   const filtered = linter.filter(files)
 
   if (filtered.length === 0) { return linter.defaultReport }
+  
   const reportFilePath = path.join(workingDirectory, '..', linter.reportFile)
   const process = spawn(linter.name, linter.args(filtered, path.join('..', linter.reportFile)), { cwd: workingDirectory })
 

--- a/runner.js
+++ b/runner.js
@@ -33,7 +33,6 @@ function run (linter, workingDirectory, files) {
   const filtered = linter.filter(files)
 
   if (filtered.length === 0) { return linter.defaultReport }
-
   const reportFilePath = path.join(workingDirectory, '..', linter.reportFile)
   const process = spawn(linter.name, linter.args(filtered, path.join('..', linter.reportFile)), { cwd: workingDirectory })
 
@@ -45,11 +44,11 @@ function run (linter, workingDirectory, files) {
   // Promise report generation
   return new Promise((resolve, reject) => {
     process.on('error', reject)
-    process.on('close', () => reportHandler(linter, reportFilePath, resolve, reject, errorLogs))
+    process.on('close', () => reportHandler(linter, path.resolve(workingDirectory), reportFilePath, resolve, reject, errorLogs))
   })
 }
 
-function reportHandler (linter, reportFilePath, resolve, reject, logs) {
+function reportHandler (linter, workingDirectory, reportFilePath, resolve, reject, logs) {
   fs.readFile(reportFilePath, 'utf8', (err, data) => {
     if (err) {
       console.log('Could not read linter results: ' + reportFilePath)
@@ -57,7 +56,7 @@ function reportHandler (linter, reportFilePath, resolve, reject, logs) {
       return reject(err)
     } else {
       const results = linter.parseResults(data)
-      const report = linter.generateReport(results)
+      const report = linter.generateReport(results, workingDirectory)
       return resolve(report)
     }
   })

--- a/runner.js
+++ b/runner.js
@@ -33,7 +33,7 @@ function run (linter, workingDirectory, files) {
   const filtered = linter.filter(files)
 
   if (filtered.length === 0) { return linter.defaultReport }
-  
+
   const reportFilePath = path.join(workingDirectory, '..', linter.reportFile)
   const process = spawn(linter.name, linter.args(filtered, path.join('..', linter.reportFile)), { cwd: workingDirectory })
 


### PR DESCRIPTION
Closes: #148 

When we refactored our code it looks like we forgot to give the right path to the issues found by Gosec. The result is that the issues are shown in the checks page but not into the "Files changed" page under the code problematic lines.

The problem is that Gosec gives the absolute path to the found problem but we are interested only to the relative path against the current working directory.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>