### PR TITLE
Add spaces in the output

### DIFF
--- a/bandit/bandit_annotations.js
+++ b/bandit/bandit_annotations.js
@@ -13,7 +13,7 @@ function getAnnotation (issue) {
   const startLine = issue.line_number
   const endLine = issue.line_number
   const annotationLevel = getAnnotationLevel(issue.issue_severity, issue.issue_confidence)
-  const title = `${issue.test_id}:${issue.test_name}`
+  const title = `${issue.test_id}: ${issue.test_name}`
   const message = issue.issue_text
 
   return {

--- a/bandit/bandit_report.js
+++ b/bandit/bandit_report.js
@@ -14,7 +14,7 @@ function createMoreInfoLinks (issues) {
   for (let issue of issues) {
     if (issuesMap.has(issue.test_id) === false) {
       issuesMap.set(issue.test_id)
-      const text = `${issue.test_id}:${issue.test_name}`
+      const text = `${issue.test_id}: ${issue.test_name}`
       moreInfo += `[${text}](${issue.more_info})\n`
     }
   }

--- a/gosec/gosec_annotations.js
+++ b/gosec/gosec_annotations.js
@@ -14,7 +14,7 @@ function getAnnotation (issue, directory) {
   const startLine = Number(issue.line)
   const endLine = startLine
   const annotationLevel = getAnnotationLevel(issue.severity, issue.confidence)
-  const title = `${issue.rule_id}:${issue.details}`
+  const title = `${issue.rule_id}: ${issue.details}`
   const message = `The issue is in the code: ${issue.code}`
 
   return {

--- a/test/bandit.report.test.js
+++ b/test/bandit.report.test.js
@@ -25,7 +25,7 @@ describe('Bandit report generation', () => {
     expect(report.annotations[0].end_line).toBe(8)
     expect(report.annotations[3].start_line).toBe(15)
     expect(report.annotations[1].path).toBe('mix.py')
-    expect(report.annotations[2].title).toBe('B305:blacklist')
+    expect(report.annotations[2].title).toBe('B305: blacklist')
 
     report.annotations.forEach(annotation => {
       expect(annotation.annotation_level).toMatch(/notice|warning|failure/)


### PR DESCRIPTION
The output title is little unreadable because there are no spaces.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>