### PR TITLE
Handle invalid go files with syntax errors

### DIFF
--- a/gosec/gosec_annotations.js
+++ b/gosec/gosec_annotations.js
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 const { getAnnotationLevel } = require('../annotations_levels')
+const { config } = require('../config')
 
 /**
  * @param {*} issue - an issue from which the annotation will be build
@@ -15,7 +16,8 @@ function getAnnotation (issue, directory) {
   const endLine = startLine
   const annotationLevel = getAnnotationLevel(issue.severity, issue.confidence)
   const title = `${issue.rule_id}: ${issue.details}`
-  const message = `The issue is in the code: ${issue.code}`
+  const message = title === config.syntaxErrorTitle ? `${issue.code}`
+    : `The issue is in the code: ${issue.code}`
 
   return {
     path,

--- a/gosec/gosec_annotations.js
+++ b/gosec/gosec_annotations.js
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 const { getAnnotationLevel } = require('../annotations_levels')
-const { config } = require('../config')
 
 /**
  * @param {*} issue - an issue from which the annotation will be build
@@ -16,8 +15,7 @@ function getAnnotation (issue, directory) {
   const endLine = startLine
   const annotationLevel = getAnnotationLevel(issue.severity, issue.confidence)
   const title = `${issue.rule_id}: ${issue.details}`
-  const message = title === config.syntaxErrorTitle ? `${issue.code}`
-    : `The issue is in the code: ${issue.code}`
+  const message = `${issue.code}`
 
   return {
     path,

--- a/linters/gosec.js
+++ b/linters/gosec.js
@@ -53,7 +53,26 @@ module.exports = class Gosec {
    * @param {Buffer} data The raw linter results data
    */
   parseResults (data) {
-    return JSON.parse(data)
+    let parsedData = JSON.parse(data)
+    let syntaxErrors = parsedData['Golang errors']
+    let filePaths = Object.keys(syntaxErrors)
+
+    for (let path of filePaths) {
+      for (let error of syntaxErrors[path]) {
+        let errAnnotation = {
+          severity: 'HIGH',
+          confidence: 'HIGH',
+          rule_id: 'ERROR',
+          details: 'Syntax error',
+          file: path,
+          code: `${error.error}`,
+          line: error.line
+        }
+        parsedData.Issues.push(errAnnotation)
+      }
+    }
+
+    return parsedData
   }
 
   /**

--- a/linters/gosec.js
+++ b/linters/gosec.js
@@ -55,20 +55,23 @@ module.exports = class Gosec {
   parseResults (data) {
     let parsedData = JSON.parse(data)
     let syntaxErrors = parsedData['Golang errors']
-    let filePaths = Object.keys(syntaxErrors)
 
-    for (let path of filePaths) {
-      for (let error of syntaxErrors[path]) {
-        let errAnnotation = {
-          severity: 'HIGH',
-          confidence: 'HIGH',
-          rule_id: 'ERROR',
-          details: 'Syntax error',
-          file: path,
-          code: `${error.error}`,
-          line: error.line
+    if (syntaxErrors) {
+      let filePaths = Object.keys(syntaxErrors)
+
+      for (let path of filePaths) {
+        for (let error of syntaxErrors[path]) {
+          let errAnnotation = {
+            severity: 'HIGH',
+            confidence: 'HIGH',
+            rule_id: 'ERROR',
+            details: 'Syntax error',
+            file: path,
+            code: `${error.error}`,
+            line: error.line
+          }
+          parsedData.Issues.push(errAnnotation)
         }
-        parsedData.Issues.push(errAnnotation)
       }
     }
 

--- a/test/fixtures/go/src/invalid_files/sum.invalid.go
+++ b/test/fixtures/go/src/invalid_files/sum.invalid.go
@@ -1,0 +1,13 @@
+package main
+
+import "fmt"
+
+func main() {
+
+	arr := []int{1, 2, 3, 4}
+	res = 0
+	for _, i := range ar {
+		res += i
+	}
+	fmt.Println(res)
+}

--- a/test/gosec.spawn.test.js
+++ b/test/gosec.spawn.test.js
@@ -4,6 +4,7 @@
 const fs = require('fs-extra')
 
 const { run } = require('../runner')
+const { config } = require('../config')
 const Gosec = require('../linters/gosec')
 
 function gosec (dir, files) {
@@ -19,6 +20,17 @@ describe('Gosec runner', () => {
     expect(report.annotations[1].start_line).toEqual(19)
     expect(report.annotations[2].start_line).toEqual(26)
     expect(report.annotations[3].start_line).toEqual(27)
+  })
+
+  test('Handles invalid go file with syntax errors', async () => {
+    const report = await gosec('test/fixtures/go/src/invalid_files', ['sum.invalid.go'])
+
+    expect(report.annotations.length).toBe(5)
+    expect(report.annotations[0].path).toEqual('sum.invalid.go')
+    expect(report.annotations[0].start_line).toBe(7)
+    expect(report.annotations[0].message).toBe('arr declared but not used')
+    expect(report.annotations[2].annotation_level).toBe('failure')
+    expect(report.annotations[4].title).toBe(config.syntaxErrorTitle)
   })
 
   test('Passes on safe file', async () => {


### PR DESCRIPTION
Related to: https://github.com/vmware/precaution/issues/142

From version 1.3 of Gosec, we get information about the possible syntax errors found from the golang parser.
That's something important to report to the user because if there are syntax errors in a file the file won't be scanned for security vulnerabilities.

Additionally, to reporting the golang syntax errors I added a unit test about this case.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>