### PR TITLE
Download more than 30 files

### DIFF
--- a/config.js
+++ b/config.js
@@ -8,7 +8,8 @@ const config = {
   noIssuesResultTitle: 'No issues found',
   noIssuesResultSummary: 'There were no issues found.',
   issuesFoundResultTitle: 'Issues found',
-  syntaxErrorTitle: 'ERROR: Syntax error'
+  syntaxErrorTitle: 'ERROR: Syntax error',
+  amountFilesListedPerPage: 30
 }
 
 const annotationsLevels = {

--- a/config.js
+++ b/config.js
@@ -9,7 +9,7 @@ const config = {
   noIssuesResultSummary: 'There were no issues found.',
   issuesFoundResultTitle: 'Issues found',
   syntaxErrorTitle: 'ERROR: Syntax error',
-  amountFilesListedPerPage: 30
+  numberFilesListedPerPage: 30
 }
 
 const annotationsLevels = {

--- a/config.js
+++ b/config.js
@@ -9,7 +9,7 @@ const config = {
   noIssuesResultSummary: 'There were no issues found.',
   issuesFoundResultTitle: 'Issues found',
   syntaxErrorTitle: 'ERROR: Syntax error',
-  numberFilesListedPerPage: 30
+  numFilesPerPage: 30
 }
 
 const annotationsLevels = {

--- a/github_api_helper.js
+++ b/github_api_helper.js
@@ -52,7 +52,7 @@ async function getPRFiles (context, number) {
     owner: owner,
     repo: repo,
     number: number,
-    per_page: config.numberFilesListedPerPage
+    per_page: config.numFilesPerPage
   })
 
   let data = filterData(response)

--- a/github_api_helper.js
+++ b/github_api_helper.js
@@ -26,7 +26,11 @@ function inProgressAPIresponse (context, headSha) {
   })
 }
 
-// Filters the files which are not relevant to us
+/**
+ * Filters the listed files and returns only the files relevant to us
+ * @param {*} rawData the raw output from list files API call
+ * @return {Promise[]<any>} the filtered GitHub response
+ */
 function filterData (rawData) {
   return rawData.data.filter(file => config.fileExtensions.reduce((acc, ext) => acc || file.filename.endsWith(ext), false))
     .filter(fileJSON => fileJSON.status !== 'removed').map(async fileInfo => {
@@ -38,17 +42,17 @@ function filterData (rawData) {
  * Get list of files modified by a pull request
  * @param {import('probot').Context} context Probot context
  * @param {number} number the pull request number inside the repository
- * @returns {Promise<any>} GitHub response
- * See https://developer.github.com/v3/pulls/#list-pull-requests-files
+ * @returns {String[]} paths to the diff files from the pull request relevant to us
  */
 async function getPRFiles (context, number) {
   const { owner, repo } = context.repo()
 
+  // See https://developer.github.com/v3/pulls/#list-pull-requests-files
   let response = await context.github.pullRequests.listFiles({
     owner: owner,
     repo: repo,
     number: number,
-    per_page: config.amountFilesListedPerPage
+    per_page: config.numberFilesListedPerPage
   })
 
   let data = filterData(response)

--- a/index.js
+++ b/index.js
@@ -104,17 +104,17 @@ async function processPullRequest (pullRequest, context) {
 
   const response = await apiHelper.getPRFiles(context, number)
   const filesDownloadedPromise = response
-    .map(async fileName => {
-      const headRevision = apiHelper.getContents(context, fileName, ref, pullRequest.head)
+    .map(async filename => {
+      const headRevision = apiHelper.getContents(context, filename, ref, pullRequest.head)
 
       // TODO: merge this code with linter-specific path resolution
-      if (fileName.endsWith('.py')) {
-        cache.saveFile(repoID, id, fileName, (await headRevision).data, 'python')
-      } else if (fileName.endsWith('.go')) {
-        cache.saveFile(repoID, id, fileName, (await headRevision).data, 'go')
+      if (filename.endsWith('.py')) {
+        cache.saveFile(repoID, id, filename, (await headRevision).data, 'python')
+      } else if (filename.endsWith('.go')) {
+        cache.saveFile(repoID, id, filename, (await headRevision).data, 'go')
       }
 
-      return fileName
+      return filename
     })
 
   // Wait until all files have been downloaded

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -99,7 +99,7 @@ describe('Bandit-linter', () => {
         owner: 'owner_login',
         repo: 'repo_name',
         number: 6,
-        per_page: config.numberFilesListedPerPage
+        per_page: config.numFilesPerPage
       })
 
       expect(github.checks.update).toHaveBeenCalledWith(expect.objectContaining({
@@ -127,7 +127,7 @@ describe('Bandit-linter', () => {
         owner: 'owner_login',
         repo: 'repo_name',
         number: 6,
-        per_page: config.numberFilesListedPerPage
+        per_page: config.numFilesPerPage
       })
 
       expect(github.checks.update).toHaveBeenCalledWith(expect.objectContaining({
@@ -155,7 +155,7 @@ describe('Bandit-linter', () => {
         owner: 'owner_login',
         repo: 'repo_name',
         number: 8,
-        per_page: config.numberFilesListedPerPage
+        per_page: config.numFilesPerPage
       })
 
       expect(github.checks.update).toHaveBeenCalledWith(expect.objectContaining({
@@ -185,7 +185,7 @@ describe('Bandit-linter', () => {
         owner: 'original_repo_owner',
         repo: 'original_repo_name',
         number: 8,
-        per_page: config.numberFilesListedPerPage
+        per_page: config.numFilesPerPage
       })
 
       expect(github.repos.getContents).toHaveBeenCalledWith(expect.objectContaining({

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -54,7 +54,7 @@ describe('Bandit-linter', () => {
         create: jest.fn().mockResolvedValue({ data: { id: 1 } }),
         update: jest.fn().mockResolvedValue({})
       },
-      numPagesOfContent: 2,
+      numPagesOfContent: 1,
       pullRequests: {
         listFiles: jest.fn(() => {
           --github.numPagesOfContent
@@ -260,6 +260,7 @@ describe('Bandit-linter', () => {
     })
 
     test('handles paging through the GitHub API', async () => {
+      github.numPagesOfContent = 2
       await app.receive(pullRequestOpenedEvent)
 
       expect(github.hasNextPage).toHaveBeenCalledTimes(2)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -19,10 +19,10 @@ const sampleSafePRFixture = require('./fixtures/pull_request.files.safe.json')
 const sampleOnlyDeletions = require('./fixtures/pull_request.deletions.json')
 const sampleDelAddModif = require('./fixtures/pull_request.deletions.modif.add.json')
 
-function mockPRContents (github, PR) {
+function mockPRContents (github, pr) {
   github.pullRequests.listFiles = jest.fn(() => {
     --github.numPagesOfContent
-    return PR
+    return pr
   })
   github.getNextPage = github.pullRequests.listFiles
 }
@@ -99,7 +99,7 @@ describe('Bandit-linter', () => {
         owner: 'owner_login',
         repo: 'repo_name',
         number: 6,
-        per_page: config.amountFilesListedPerPage
+        per_page: config.numberFilesListedPerPage
       })
 
       expect(github.checks.update).toHaveBeenCalledWith(expect.objectContaining({
@@ -127,7 +127,7 @@ describe('Bandit-linter', () => {
         owner: 'owner_login',
         repo: 'repo_name',
         number: 6,
-        per_page: config.amountFilesListedPerPage
+        per_page: config.numberFilesListedPerPage
       })
 
       expect(github.checks.update).toHaveBeenCalledWith(expect.objectContaining({
@@ -155,7 +155,7 @@ describe('Bandit-linter', () => {
         owner: 'owner_login',
         repo: 'repo_name',
         number: 8,
-        per_page: config.amountFilesListedPerPage
+        per_page: config.numberFilesListedPerPage
       })
 
       expect(github.checks.update).toHaveBeenCalledWith(expect.objectContaining({
@@ -185,7 +185,7 @@ describe('Bandit-linter', () => {
         owner: 'original_repo_owner',
         repo: 'original_repo_name',
         number: 8,
-        per_page: config.amountFilesListedPerPage
+        per_page: config.numberFilesListedPerPage
       })
 
       expect(github.repos.getContents).toHaveBeenCalledWith(expect.objectContaining({
@@ -266,13 +266,14 @@ describe('Bandit-linter', () => {
       expect(github.hasNextPage).toHaveBeenCalledTimes(2)
       expect(github.getNextPage).toHaveBeenCalledTimes(1)
 
-      const expectedRes = { 'data':
-        [
-          { 'filename': 'https.py', 'status': 'added' },
-          { 'filename': 'cgi.py', 'status': 'added' },
-          { 'filename': 'twisted_dir.py', 'status': 'added' },
-          { 'filename': 'twisted_script.py', 'status': 'added' }
-        ]
+      const expectedRes = {
+        'data':
+          [
+            { 'filename': 'https.py', 'status': 'added' },
+            { 'filename': 'cgi.py', 'status': 'added' },
+            { 'filename': 'twisted_dir.py', 'status': 'added' },
+            { 'filename': 'twisted_script.py', 'status': 'added' }
+          ]
       }
       expect(github.getNextPage).toHaveNthReturnedWith(1, expectedRes)
       expect(github.pullRequests.listFiles).toHaveNthReturnedWith(1, expectedRes)


### PR DESCRIPTION
Related to: https://github.com/vmware/precaution/issues/134

In order to download all of the diff files from a pull request, we have to access the data from GitHub page by page.

Also, there is an option to customize how many results do you want per page.

I added a unit test handling the paging but I  had to change the other unit tests a little bit in order to achieve that.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>