### PR TITLE
TSLint spawn functionality

### DIFF
--- a/config.js
+++ b/config.js
@@ -3,7 +3,7 @@
 
 const config = {
   cleanupAfterRun: true,
-  fileExtensions: ['.py', '.pyw', '.go'],
+  fileExtensions: ['.py', '.pyw', '.go', 'js', 'ts'],
   checkRunName: 'Precaution',
   noIssuesResultTitle: 'No issues found',
   noIssuesResultSummary: 'There were no issues found.',

--- a/linters/index.js
+++ b/linters/index.js
@@ -3,8 +3,10 @@
 
 const Bandit = require('./bandit')
 const Gosec = require('./gosec')
+const TSLint = require('./tslint')
 
 module.exports = {
   BANDIT: new Bandit(),
-  GOSEC: new Gosec()
+  GOSEC: new Gosec(),
+  TSLint: new TSLint()
 }

--- a/linters/index.js
+++ b/linters/index.js
@@ -8,5 +8,5 @@ const TSLint = require('./tslint')
 module.exports = {
   BANDIT: new Bandit(),
   GOSEC: new Gosec(),
-  TSLint: new TSLint()
+  TSLINT: new TSLint()
 }

--- a/linters/tslint.js
+++ b/linters/tslint.js
@@ -1,0 +1,68 @@
+// Copyright 2019 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+const cache = require('../cache')
+const report = require('../tslint/tslint_report')
+
+module.exports = class TSLint {
+  get name () {
+    return 'tslint'
+  }
+
+  /**
+   * The name of the generated report file
+   */
+  get reportFile () {
+    return 'tslint.json'
+  }
+
+  get defaultReport () {
+    return { annotations: [], issueCount: { errors: 0, warnings: 0, notices: 0 }, moreInfo: '' }
+  }
+
+  /**
+   * Retains files that can be analyzed by this linter
+   * @param {string[]} files Names of files to analyze
+   * @returns {string[]} Filtered list of file names
+   */
+  filter (files) {
+    return files.filter(name => name.endsWith('.js') || name.endsWith('ts'))
+  }
+
+  /**
+   * Returns the working directory for this analysis
+   * @param {string} repoID Unique repository id
+   * @param {string} prID PR id in repository
+   */
+  workingDirectoryForPR (repoID, prID) {
+    return cache.getBranchPath(repoID, prID, 'tslint')
+  }
+
+  /**
+   * Builds the command line args to pass to the linter process
+   * @param {string[]} files List of files to analyze
+   * @param {string} reportPath Path to the report file relative to working directory
+   */
+  args (files, reportPath) {
+    return ['-c', '../../../tslint/tslint.json', '--format', 'json', '-o', reportPath, ...files]
+  }
+
+  /**
+   * Parses the linter results
+   * @param {Buffer} data The raw linter results data
+   */
+  parseResults (data) {
+    return JSON.parse(data)
+  }
+
+  /**
+   * Generates a report in the format expected by GitHub checks
+   * from the linter results
+   * @param {any} results Linter results
+   * @param {any} directory current working directory
+   * @returns GitHub checks report
+   */
+  generateReport (results, directory) {
+    return report(results, directory)
+  }
+}

--- a/linters/tslint.js
+++ b/linters/tslint.js
@@ -13,7 +13,7 @@ module.exports = class TSLint {
    * The name of the generated report file
    */
   get reportFile () {
-    return 'tslint.json'
+    return 'tslint_output.json'
   }
 
   get defaultReport () {

--- a/test/fixtures/typescript/safe.js
+++ b/test/fixtures/typescript/safe.js
@@ -1,0 +1,12 @@
+
+function sumArray (array) {
+  let result = 0
+  for (let element of array) {
+    result += element
+  }
+  return result
+}
+
+let arr = [1, 2, 20, 30]
+
+console.log(sumArray(arr))

--- a/test/fixtures/typescript/vulnerable.js
+++ b/test/fixtures/typescript/vulnerable.js
@@ -1,7 +1,7 @@
 const fs = require('fs-extra')
 var stdin = process.openStdin()
 
-function bildngSQLQuery () {
+function buildingSQLQuery () {
   const userId = 1
   const query = `SELECT * FROM users WHERE id = ${userId}`
   return query

--- a/test/fixtures/typescript/vulnerable.js
+++ b/test/fixtures/typescript/vulnerable.js
@@ -19,7 +19,7 @@ function openFile () {
   })
 }
 
-let query = bildngSQLQuery()
+let query = buildingSQLQuery()
 let templateGreeting = getTemplateGreeting('Martin')
 
 console.log('The query is: ', query)

--- a/test/fixtures/typescript/vulnerable.js
+++ b/test/fixtures/typescript/vulnerable.js
@@ -1,0 +1,28 @@
+const fs = require('fs-extra')
+var stdin = process.openStdin()
+
+function bildngSQLQuery () {
+  const userId = 1
+  const query = `SELECT * FROM users WHERE id = ${userId}`
+  return query
+}
+
+function getTemplateGreeting (name) {
+  let classicString = `Hello ${name}`
+  return eval('`' + classicString + '`') // eslint-disable-line
+}
+
+function openFile () {
+  console.log('Give me a file path to open: ')
+  stdin.addListener('data', function (filePath) {
+    fs.open(filePath)
+  })
+}
+
+let query = bildngSQLQuery()
+let templateGreeting = getTemplateGreeting('Martin')
+
+console.log('The query is: ', query)
+console.log('The greeting is: ', templateGreeting)
+
+openFile()

--- a/test/tslint.spawn.test.js
+++ b/test/tslint.spawn.test.js
@@ -1,0 +1,38 @@
+// Copyright 2019 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+const fs = require('fs-extra')
+const { run } = require('../runner')
+
+const TSLint = require('../linters/tslint')
+
+function tslint (dir, files) {
+  return run(new TSLint(), dir, files)
+}
+
+describe('TSLint runner', () => {
+  test('Finds issues in vulnerable file', async () => {
+    const report = await tslint('test/fixtures/typescript', ['vulnerable.js'])
+
+    expect(report.annotations.length).toEqual(3)
+    expect(report.annotations[0].start_line).toEqual(12)
+    expect(report.annotations[1].start_line).toEqual(18)
+    expect(report.annotations[2].start_line).toEqual(6)
+  })
+
+  test('Passes on safe file', async () => {
+    const report = await tslint('test/fixtures/typescript', ['safe.js'])
+
+    expect(report.annotations.length).toEqual(0)
+  })
+
+  test('Handles empty input', async () => {
+    const report = await tslint('test/fixtures/typescript', [])
+
+    expect(report.annotations.length).toEqual(0)
+  })
+
+  afterEach(() => {
+    fs.remove('test/fixtures/tslint.json')
+  })
+})

--- a/test/tslint.spawn.test.js
+++ b/test/tslint.spawn.test.js
@@ -33,6 +33,6 @@ describe('TSLint runner', () => {
   })
 
   afterEach(() => {
-    fs.remove('test/fixtures/tslint.json')
+    fs.remove('test/fixtures/tslint_output.json')
   })
 })


### PR DESCRIPTION
I added a TSLint spawn functionality + unit tests for that.

Because the TSLint rules for TypeScript are 100% compatible with JavaScript (those are the words from the maintainer of the TSLint security rules project) I tested only on vulnerable JavaScript file.

Sadly, TSLint doesn't report you when you try to scan an invalid file with syntax errors. That's why I haven't added more sophisticated functionality in parseResults function in linters/tslint.js 

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>