### PR TITLE
Enable Mergify for automatic merges

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,12 @@
+pull_request_rules:
+  - name: merge when CI passes and 1 approved review
+    conditions:
+      - "#approved-reviews-by>=1"
+      - status-success=Travis CI - Pull Request
+      - base=master
+      - label!=work-in-progress
+      - label=ready-to-merge
+    actions:
+      merge:
+        method: rebase
+        rebase_fallback: squash


### PR DESCRIPTION
The Mergify GitHub App is already installed to the Precaution
repo.  This commit enables the app by setting necessary configuration
via the YAML file.

Note that this config sets the following conditions
- The number of approved code reviews must be 1 or greater
- The Travis CI must pass
- Enabled on branch master only
- Don't merge PRs with work-in-progress label
- And finally, only merge with label ready-to-merge

https://doc.mergify.io

Signed-off-by: Eric Brown <browne@vmware.com>