### PR TITLE
Linters output files rename

### DIFF
--- a/linters/bandit.js
+++ b/linters/bandit.js
@@ -14,7 +14,7 @@ module.exports = class Bandit {
    * The name of the generated report file
    */
   get reportFile () {
-    return 'bandit.json'
+    return 'bandit_output.json'
   }
 
   get defaultReport () {

--- a/linters/gosec.js
+++ b/linters/gosec.js
@@ -14,7 +14,7 @@ module.exports = class Gosec {
    * The name of the generated report file
    */
   get reportFile () {
-    return 'gosec.json'
+    return 'gosec_output.json'
   }
 
   get defaultReport () {

--- a/test/bandit.spawn.test.js
+++ b/test/bandit.spawn.test.js
@@ -45,6 +45,6 @@ describe('Bandit runner', () => {
   })
 
   afterEach(() => {
-    fs.remove('test/fixtures/bandit.json')
+    fs.remove('test/fixtures/bandit_output.json')
   })
 })

--- a/test/gosec.spawn.test.js
+++ b/test/gosec.spawn.test.js
@@ -54,6 +54,6 @@ describe('Gosec runner', () => {
   })
 
   afterEach(() => {
-    fs.remove('test/fixtures/go/src/gosec.json')
+    fs.remove('test/fixtures/go/src/gosec_output.json')
   })
 })


### PR DESCRIPTION
It's a lot clearer what is bandit_output.json instead of just bandit.json.

Also, maybe we would have to use configuration files for the linters in future and many times those files are called "linterName.json".
We already stumped upon that situation with TSLint.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>