### PR TITLE
Add js and ts files into unit tests

### DIFF
--- a/test/fixtures/annotations/tslint_mix_annotations.json
+++ b/test/fixtures/annotations/tslint_mix_annotations.json
@@ -1,0 +1,25 @@
+{
+  "annotations": [ 
+    { "path": "vulnerable.js",
+      "start_line": 12,
+      "end_line": 12,
+      "annotation_level": "warning",
+      "title": "tsr-detect-eval-with-expression",
+      "message": "eval with argument of type BinaryExpression"
+    },
+    { "path": "vulnerable.js",
+      "start_line": 18,
+      "end_line": 18,
+      "annotation_level": "notice",
+      "title": "tsr-detect-non-literal-fs-filename",
+      "message": "Found fs.open with non-literal argument at index 0"
+    },
+    { "path": "vulnerable.js",
+      "start_line": 21,
+      "end_line": 21,
+      "annotation_level": "failure",
+      "title": "tsr-detect-sql-literal-injection",
+      "message": "Found possible SQL injection"
+    }
+  ]
+}

--- a/test/fixtures/pull_request.files.mix.json
+++ b/test/fixtures/pull_request.files.mix.json
@@ -13,6 +13,14 @@
       "status": "added"
     },
     {
+      "filename": "vulnerable.js",
+      "status": "added"
+    },
+    {
+      "filename": "vulnerable.ts",
+      "status": "added"
+    },
+    {
       "filename": "AbstractJavaFileFactoryServiceProvider.java",
       "status": "added"
     },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -42,6 +42,9 @@ describe('Precaution workflow', () => {
     mockFiles['networking_binding.go'] = fs.readFileSync('test/fixtures/go/src/vulnerable_package/networking_binding.go', 'utf8')
     mockFiles['bad_test_file.go'] = fs.readFileSync('test/fixtures/go/src/vulnerable_package/bad_test_file.go', 'utf8')
     mockFiles['hello.go'] = fs.readFileSync('test/fixtures/go/src/safe/hello_world.go', 'utf8')
+    // Mock the files as empty strings because we don't analyze their content anyway
+    mockFiles['vulnerable.js'] = ''
+    mockFiles['vulnerable.ts'] = ''
   })
 
   beforeEach(() => {
@@ -211,6 +214,12 @@ describe('Precaution workflow', () => {
       }))
       expect(github.repos.getContents).toHaveBeenCalledWith(expect.objectContaining({
         path: 'networking_binding.go'
+      }))
+      expect(github.repos.getContents).toHaveBeenCalledWith(expect.objectContaining({
+        path: 'vulnerable.js'
+      }))
+      expect(github.repos.getContents).toHaveBeenCalledWith(expect.objectContaining({
+        path: 'vulnerable.ts'
       }))
       expect(github.repos.getContents).not.toHaveBeenCalledWith(expect.objectContaining({
         path: 'AbstractJavaFileFactoryServiceProvider.java'


### PR DESCRIPTION
Connected with issue: https://github.com/vmware/precaution/issues/160

When we check if we download the right files it's a good idea to add js
and ts files there too. Same applies in the merge report unit tests.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>