### PR TITLE
Move "reference links" title to config.js

### DIFF
--- a/bandit/bandit_report.js
+++ b/bandit/bandit_report.js
@@ -9,7 +9,7 @@ const { countIssueLevels } = require('../annotations_levels')
  */
 function createMoreInfoLinks (issues) {
   let issuesMap = new Map()
-  let moreInfo = 'For more information about the issues follow the links: \n'
+  let moreInfo = ''
 
   for (let issue of issues) {
     if (issuesMap.has(issue.test_id) === false && issue.more_info) {

--- a/config.js
+++ b/config.js
@@ -9,6 +9,7 @@ const config = {
   noIssuesResultSummary: 'There were no issues found.',
   issuesFoundResultTitle: 'Issues found',
   syntaxErrorTitle: 'ERROR: Syntax error',
+  moreInfoTitle: 'For more information about the issues follow the links: \n',
   numFilesPerPage: 30,
   numAnnotationsPerUpdate: 50
 }

--- a/merge_reports.js
+++ b/merge_reports.js
@@ -39,6 +39,6 @@ module.exports = (reports) => {
 
   const summary = mergeSummaries(reports.map(r => r.issueCount))
 
-  const text = reports.map(r => r.moreInfo).reduce((a, b) => a + b, '')
+  const text = config.moreInfoTitle + reports.map(r => r.moreInfo).reduce((a, b) => a + b, '')
   return { title: config.issuesFoundResultTitle, summary, annotations, text }
 }


### PR DESCRIPTION
It's better to have that "reference links" title separated from the
Bandit "more info" implementation. That way when we have reference links
from the other linters it will be possible and easier to add them.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>