### PR TITLE
 Add support for TSLint reference links

### DIFF
--- a/config.js
+++ b/config.js
@@ -10,6 +10,7 @@ const config = {
   issuesFoundResultTitle: 'Issues found',
   syntaxErrorTitle: 'ERROR: Syntax error',
   moreInfoTitle: 'For more information about the issues follow the links: \n',
+  tslintProjectWebsite: 'https://github.com/webschik/tslint-config-security',
   numFilesPerPage: 30,
   numAnnotationsPerUpdate: 50
 }

--- a/package.json
+++ b/package.json
@@ -39,8 +39,10 @@
     "lint": "standard --fix"
   },
   "dependencies": {
+    "cheerio": "^1.0.0-rc.3",
     "fs-extra": "^7.0.0",
     "probot": "^7.4.0",
+    "request": "^2.88.0",
     "tslint": "^5.14.0",
     "typescript": "^3.3.4000",
     "tslint-config-security": "^1.15.0"

--- a/test/external.dependencies.test.js
+++ b/test/external.dependencies.test.js
@@ -1,0 +1,34 @@
+// Copyright 2019 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+const { config } = require('../config')
+const { jsRules } = require('../tslint/tslint.json')
+
+const request = require('request')
+const cheerio = require('cheerio')
+
+describe('Checks for documentation websites', () => {
+  test('Check if TSLint plugin documentation website is online', async () => {
+    request(config.tslintProjectWebsite, async (err, response, _) => {
+      if (err) {
+        throw new Error(err)
+      }
+      expect(response.statusCode === 200 || response.statusCode === 201).toBeTruthy()
+    })
+  })
+
+  test('Check documentation for every rule on the TSLint plugin webpage', async () => {
+    const rules = Object.keys(jsRules)
+    request(config.tslintProjectWebsite, (err, _, body) => {
+      if (err) {
+        throw new Error(err)
+      }
+      let $ = cheerio.load(body)
+      let result = ''
+      for (let ruleName of rules) {
+        result = $('#user-content-' + ruleName).attr('href')
+        expect(result).toEqual('#' + ruleName)
+      }
+    })
+  })
+})

--- a/tslint/tslint_report.js
+++ b/tslint/tslint_report.js
@@ -3,6 +3,24 @@
 
 const { getAnnotation } = require('./tslint_annotations')
 const { countIssueLevels } = require('../annotations_levels')
+const { config } = require('../config')
+
+/**
+ * @param {*} issues the issues found by TSLint
+ */
+function createMoreInfoLinks (issues) {
+  let issuesMap = new Map()
+  let moreInfo = ''
+
+  for (let issue of issues) {
+    if (issuesMap.has(issue.ruleName) === false) {
+      issuesMap.set(issue.ruleName)
+      const linkToDoc = config.tslintProjectWebsite + '#' + issue.ruleName
+      moreInfo += `[${issue.ruleName}](${linkToDoc})\n`
+    }
+  }
+  return moreInfo
+}
 
 /**
  * Process TSLint output (generate annotations, count issue levels)
@@ -12,7 +30,7 @@ const { countIssueLevels } = require('../annotations_levels')
 module.exports = (results) => {
   const annotations = results.map(issue => getAnnotation(issue))
   const issueCount = countIssueLevels(annotations)
-  const moreInfo = ''
+  const moreInfo = annotations.length > 0 ? createMoreInfoLinks(results) : ''
 
   return { annotations, issueCount, moreInfo }
 }


### PR DESCRIPTION
 Add support for TSLint reference links

Because TSLint doesn't provide us with reference links and doesn't have
an API for such metadata as explained by the developer of
tslint-config-security: webschik/tslint-config-security#17

All rules are documented as part of the README for
tslint-config-security on GitHub, therefore we can use this
documentation to provide reference links.

Another thing we should check is if every rule has a documentation on
the project webpage and do we point to that documentation.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>