### PR TITLE
Add machinery and docs for local generation of documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ results.json
 *.pem
 .env
 bin/
+
+Gemfile.lock
+docs/_site
+
+*~

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,5 @@
+# Copyright 2019 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+
+source 'https://rubygems.org'
+gem 'github-pages', group: :jekyll_plugins

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,5 +2,3 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 theme: jekyll-theme-slate
-plugins:
-  - jekyll-relative-links

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,5 +30,6 @@ Precaution currently supports analysis of python files via Bandit and go files v
 - [Initial setup](initial_setup.md)
 - [False positives and how to handle them](false_positivies.md)
 - [Setting up a manual deployment](manual_deployment.md)
+- [Building this documentation locally](local_docs_build.md)
 - [Debugging with VSCode](local_development.md)
 - [Architecture](architecture.md)

--- a/docs/local_docs_build.md
+++ b/docs/local_docs_build.md
@@ -1,0 +1,22 @@
+<!--
+    Copyright 2019 VMware, Inc.
+    SPDX-License-Identifier: BSD-2-Clause
+-->
+
+# Building documentation locally
+
+When making changes to the documentation it's useful to be able to test the
+changes to ensure they won't break GitHub pages.
+
+Local testing (and debugging of) the GitHub Pages can be done using Bundler
+(`gem install bundler`) as follows:
+
+1. Ensure your local dependencies are up-to-date:
+```shell
+   $ bundle update github-pages
+```
+2. Build the local copy of the pages:
+```
+   $ bundle exec jekyll serve
+```
+3. Preview docs at [localhost:4000](http://localhost:4000)


### PR DESCRIPTION
Some changes to make generating documentation a bit nicer:
1) Add Gemfile to ease generating docs locally
2) Document the process for generating the documentation