### PR TITLE
Change layout of documentation index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,31 +5,32 @@
 
 # Precaution
 
-[![Build Status](https://travis-ci.com/vmware/precaution.svg?branch=master)](https://travis-ci.com/vmware/precaution)
-[![Coverage Status](https://codecov.io/gh/vmware/precaution/branch/master/graph/badge.svg)](https://codecov.io/gh/vmware/precaution)
-[![License](https://img.shields.io/badge/License-BSD%202--Clause-orange.svg)](https://github.com/vmware/precaution/blob/master/LICENSE.txt)
-[![Slack](https://img.shields.io/badge/slack-join%20chat%20%E2%86%92-e01563.svg)](https://code.vmware.com/web/code/join)
-
 ## Overview
 
-Precaution provides simple, automated code reviews for GitHub projects by running
-code linters with a security focus on all pull requests.
+Precaution provides simple, automated code reviews for GitHub projects by running code linters with a security focus on all pull requests.
 
-GitHub integration is made through the GitHub app interface and the checks API (beta),
-which allows results to be presented directly as inline annotations instead of
-a pass/fail status report.
+Precaution currently supports analysis of:
+* Go files via [Gosec](https://github.com/securego/gosec)
+* JavaScript and TypeScript via [TSLint](https://github.com/palantir/tslint) and [tslint-config-security](https://github.com/webschik/tslint-config-security)
+* Python files via [Bandit](https://github.com/PyCQA/bandit)
 
-Precaution currently supports analysis of python files via Bandit and go files via Gosec. New languages may be added in future.
+## Using the Precaution GitHub App
 
-* Documentation: [vmware/precaution/docs](https://vmware.github.io/precaution/)
-* Source: [vmware/precaution](https://github.com/vmware/precaution)
-* Bugs: [vmware/precaution/issues](https://github.com/vmware/precaution/issues)
+- [Initial setup for your repository](initial_setup.md)
+- [Marking code to ignore with exclusions](false_positivies.md)
 
-## Additional documentation
+## Deploying your own instance of Precaution
 
-- [Initial setup](initial_setup.md)
-- [False positives and how to handle them](false_positivies.md)
 - [Setting up a manual deployment](manual_deployment.md)
-- [Building this documentation locally](local_docs_build.md)
+
+## Developing Precaution
+
 - [Debugging with VSCode](local_development.md)
 - [Architecture](architecture.md)
+- [Building this documentation locally](local_docs_build.md)
+
+## Precaution community
+
+* Fork us on GitHub: [vmware/precaution](https://github.com/vmware/precaution)
+* File bugs and enhancement requests: [vmware/precaution/issues](https://github.com/vmware/precaution/issues)
+* Chat with us on Slack: [VMware Code](https://code.vmware.com/web/code/join)


### PR DESCRIPTION
The main contribution here is 7aa6edd (the top 4 commits are #186, #195 and #196 - this PR can't land until they are merged) and the PR is tagged as WIP whilst we discuss, it will likely need follow-on commits.

I've changed the documentation index layout so that doesn't duplicate content from the README and is more focused on being a landing site for users and potential contributors. I've split the documentation into 4 sections:
1) Using Precaution
2) Deploying Precaution
3) Developing Precaution
4) Precaution community

It may make sense to squash 3 and 4 into a "Contributing to Precaution", or similar, section.

As our documentation grows we might want to move developing/contributing to a separate page?

## Possible action items
- [ ] Re-title 'False positives and how to handle them'
- [ ] Combine 'Developing' and 'Community' sections into 'Contributing'
- [ ] Split content into two explicit landing pages; one for application users and another for those deploying and developing Precaution