### PR TITLE
Update the list of contributors

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,15 +2,23 @@
   "name": "precaution",
   "version": "1.0.0",
   "description": "GitHub App for PR security linting",
-  "author": "Martin Vrachev <martin.vrachev@gmail.com> (d)",
   "contributors": [
     {
       "name": "Antoine Salon",
       "url": "https://github.com/evqna"
     },
     {
+      "name": "Eric Brown",
+      "url": "https://github.com/ericwb"
+    },
+    {
+      "name": "Joshua Lock",
+      "url": "https://github.com/joshuagl"
+    },
+    {
       "name": "Martin Vrachev",
-      "email": "mvrachev@vmware.com"
+      "email": "mvrachev@vmware.com",
+      "url": "https://github.com/mvrachev"
     }
   ],
   "license": "BSD-2",


### PR DESCRIPTION
The contributor list was outdated. This commit also removes the
author since no single person has "authored" the code. Ideally
we could set the author to a mailing list, but we currently don't
have one.

Partially-fixes #166

Signed-off-by: Eric Brown <browne@vmware.com>