### PR TITLE
Make documentation links relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ and communicate with the checks API.
 
 ## Additional documentation
 
-- [Initial setup](https://vmware.github.io/precaution/initial_setup.html)
-- [False positives and how to handle them](https://vmware.github.io/precaution/false_positivies.html)
-- [Setting up a manual deployment](https://vmware.github.io/precaution/manual_deployment.html)
-- [Debugging with VSCode](https://vmware.github.io/precaution/local_development.html)
-- [Architecture](https://vmware.github.io/precaution/architecture.html)
+- [Initial setup](docs/initial_setup.md)
+- [False positives and how to handle them](docs/false_positivies.md)
+- [Setting up a manual deployment](docs/manual_deployment.md)
+- [Debugging with VSCode](docs/local_development.md)
+- [Architecture](docs/architecture.md)
 
 ## Contributing
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,6 @@
-# Copyright 2018 VMware, Inc.
+# Copyright 2019 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 
 theme: jekyll-theme-slate
+plugins:
+  - jekyll-relative-links

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,11 +25,10 @@ Precaution currently supports analysis of python files via Bandit and go files v
 * Source: [vmware/precaution](https://github.com/vmware/precaution)
 * Bugs: [vmware/precaution/issues](https://github.com/vmware/precaution/issues)
 
-
 ## Additional documentation
 
-- [Initial setup](https://vmware.github.io/precaution/initial_setup.html)
-- [False positives and how to handle them](https://vmware.github.io/precaution/false_positivies.html)
-- [Setting up a manual deployment](https://vmware.github.io/precaution/manual_deployment.html)
-- [Debugging with VSCode](https://vmware.github.io/precaution/local_development.html)
-- [Architecture](https://vmware.github.io/precaution/architecture.html)
+- [Initial setup](initial_setup.md)
+- [False positives and how to handle them](false_positivies.md)
+- [Setting up a manual deployment](manual_deployment.md)
+- [Debugging with VSCode](local_development.md)
+- [Architecture](architecture.md)


### PR DESCRIPTION
Enable relative links so that when running a local Jekyll instance or
browsing the Markdown documentation files from the GitHub file browser
documentation links don't take us away from the GitHub browser.
The Jekyll jekyll-relative-links plugin is enabled by default on GitHub
pages:
https://help.github.com/en/articles/configuring-jekyll-plugins#default-plugins

Signed-off-by: Joshua Lock <jlock@vmware.com>