### PR TITLE
Make all tests asynchronous

### DIFF
--- a/test/annotation.levels.test.js
+++ b/test/annotation.levels.test.js
@@ -5,51 +5,51 @@ const { annotationsLevels } = require('../config')
 const { getAnnotationLevel } = require('../annotations_levels')
 
 describe('Tests for annotation levels on issues with HIGH severity', () => {
-  test('HIGH severity and HIGH confidence', () => {
+  test('HIGH severity and HIGH confidence', async () => {
     const trueAnnotationLevel = getAnnotationLevel('HIGH', 'HIGH')
     expect(trueAnnotationLevel).toEqual(annotationsLevels.severityHIGHconfidenceHIGH)
   })
 
-  test('HIGH severity and MEDIUM confidence', () => {
+  test('HIGH severity and MEDIUM confidence', async () => {
     const trueAnnotationLevel = getAnnotationLevel('HIGH', 'MEDIUM')
     expect(trueAnnotationLevel).toEqual(annotationsLevels.severityHIGHconfidenceMEDIUM)
   })
 
-  test('HIGH severity and LOW confidence', () => {
+  test('HIGH severity and LOW confidence', async () => {
     const trueAnnotationLevel = getAnnotationLevel('HIGH', 'LOW')
     expect(trueAnnotationLevel).toEqual(annotationsLevels.severityHIGHconfidenceLOW)
   })
 })
 
 describe('Tests for annotation levels on issues with MEDIUM severity', () => {
-  test('MEDIUM severity and HIGH confidence', () => {
+  test('MEDIUM severity and HIGH confidence', async () => {
     const trueAnnotationLevel = getAnnotationLevel('MEDIUM', 'HIGH')
     expect(trueAnnotationLevel).toEqual(annotationsLevels.severityMEDIUMconfidenceHIGH)
   })
 
-  test('MEDIUM severity and MEDIUM confidence', () => {
+  test('MEDIUM severity and MEDIUM confidence', async () => {
     const trueAnnotationLevel = getAnnotationLevel('MEDIUM', 'MEDIUM')
     expect(trueAnnotationLevel).toEqual(annotationsLevels.severityMEDIUMconfidenceMEDIUM)
   })
 
-  test('MEDIUM severity and LOW confidence', () => {
+  test('MEDIUM severity and LOW confidence', async () => {
     const trueAnnotationLevel = getAnnotationLevel('MEDIUM', 'LOW')
     expect(trueAnnotationLevel).toEqual(annotationsLevels.severityMEDIUMconfidenceLOW)
   })
 })
 
 describe('Tests for annotation levels on issues with LOW severity', () => {
-  test('LOW severity and HIGH confidence', () => {
+  test('LOW severity and HIGH confidence', async () => {
     const trueAnnotationLevel = getAnnotationLevel('LOW', 'HIGH')
     expect(trueAnnotationLevel).toEqual(annotationsLevels.severityLOWconfidenceHIGH)
   })
 
-  test('LOW severity and MEDIUM confidence', () => {
+  test('LOW severity and MEDIUM confidence', async () => {
     const trueAnnotationLevel = getAnnotationLevel('LOW', 'MEDIUM')
     expect(trueAnnotationLevel).toEqual(annotationsLevels.severityLOWconfidenceMEDIUM)
   })
 
-  test('LOW severity and LOW confidence', () => {
+  test('LOW severity and LOW confidence', async () => {
     const trueAnnotationLevel = getAnnotationLevel('LOW', 'LOW')
     expect(trueAnnotationLevel).toEqual(annotationsLevels.severityLOWconfidenceLOW)
   })

--- a/test/bandit.report.test.js
+++ b/test/bandit.report.test.js
@@ -20,7 +20,7 @@ describe('Bandit report generation', () => {
     expect(report).toHaveProperty('moreInfo')
   })
 
-  test('Creates correct annotations', () => {
+  test('Creates correct annotations', async () => {
     expect(report.annotations).toHaveLength(4)
     expect(report.annotations[0].end_line).toBe(8)
     expect(report.annotations[3].start_line).toBe(15)
@@ -33,7 +33,7 @@ describe('Bandit report generation', () => {
     })
   })
 
-  test('Creates correct issue count', () => {
+  test('Creates correct issue count', async () => {
     expect(report.issueCount.errors).toBe(1)
     expect(report.issueCount.warnings).toBe(3)
     expect(report.issueCount.notices).toBe(0)

--- a/test/check.run.conclusion.test.js
+++ b/test/check.run.conclusion.test.js
@@ -4,29 +4,29 @@
 const { getConclusion } = require('../github_api_helper')
 
 describe('Check run conclusions tests', () => {
-  test('Empty annotations', () => {
+  test('Empty annotations', async () => {
     const trueConclusion = getConclusion([])
     expect(trueConclusion).toEqual('success')
   })
 
-  test('Undefined annotations', () => {
+  test('Undefined annotations', async () => {
     const trueConclusion = getConclusion('undefined')
     expect(trueConclusion).toEqual('success')
   })
 
-  test('Mixed annotation levels', () => {
+  test('Mixed annotation levels', async () => {
     const { annotations } = require('./fixtures/annotations/mixed_levels_annotations.json')
     const trueConclusion = getConclusion(annotations)
     expect(trueConclusion).toEqual('failure')
   })
 
-  test('Warning and neutral annotations', () => {
+  test('Warning and neutral annotations', async () => {
     const { annotations } = require('./fixtures/annotations/warning_neutral_annotations.json')
     const trueConclusion = getConclusion(annotations)
     expect(trueConclusion).toEqual('neutral')
   })
 
-  test('Neutral annotations', () => {
+  test('Neutral annotations', async () => {
     const { annotations } = require('./fixtures/annotations/neutral_annotations.json')
     const trueConclusion = getConclusion(annotations)
     expect(trueConclusion).toEqual('success')

--- a/test/gosec.report.test.js
+++ b/test/gosec.report.test.js
@@ -12,7 +12,7 @@ describe('Gosec report generation', () => {
     report = generateReport(gosecResults, 'test/fixtures/go/src')
   })
 
-  test('Creates correct report structure', () => {
+  test('Creates correct report structure', async () => {
     expect(report).toHaveProperty('annotations')
     expect(report).toHaveProperty('issueCount.errors')
     expect(report).toHaveProperty('issueCount.warnings')
@@ -20,7 +20,7 @@ describe('Gosec report generation', () => {
     expect(report).toHaveProperty('moreInfo')
   })
 
-  test('Creates correct annotations', () => {
+  test('Creates correct annotations', async () => {
     expect(report.annotations).toHaveLength(6)
     expect(report.annotations[0].end_line).toBe(16)
     expect(report.annotations[3].start_line).toBe(28)
@@ -33,7 +33,7 @@ describe('Gosec report generation', () => {
     })
   })
 
-  test('Creates correct issue count', () => {
+  test('Creates correct issue count', async () => {
     expect(report.issueCount.errors).toBe(1)
     expect(report.issueCount.warnings).toBe(5)
     expect(report.issueCount.notices).toBe(0)

--- a/test/merge.reports.test.js
+++ b/test/merge.reports.test.js
@@ -17,7 +17,7 @@ const report = (issueCount, annotations) => {
 }
 
 describe('Merge reports tests from Bandit and Gosec reports', () => {
-  test('No issues', () => {
+  test('No issues', async () => {
     const banditReport = report(noIssues, [])
     const gosecReport = report(noIssues, [])
     const tslintReport = report(noIssues, [])
@@ -28,7 +28,7 @@ describe('Merge reports tests from Bandit and Gosec reports', () => {
     expect(result.annotations).toHaveLength(0)
   })
 
-  test('Bandit issues', () => {
+  test('Bandit issues', async () => {
     // We don't need the issue count to correspond to the actual annotations (code handles them separately)
     const banditReport = report(someIssues, banditAnnotations)
     const gosecReport = report(noIssues, [])
@@ -44,7 +44,7 @@ describe('Merge reports tests from Bandit and Gosec reports', () => {
     expect(result.annotations).toEqual(banditAnnotations)
   })
 
-  test('Gosec issues', () => {
+  test('Gosec issues', async () => {
     const banditReport = report(noIssues, [])
     const gosecReport = report(moreIssues, gosecAnnotations)
     const tslintReport = report(noIssues, [])
@@ -58,7 +58,7 @@ describe('Merge reports tests from Bandit and Gosec reports', () => {
     expect(result.annotations).toEqual(gosecAnnotations)
   })
 
-  test('TSLint issues', () => {
+  test('TSLint issues', async () => {
     const banditReport = report(noIssues, [])
     const gosecReport = report(noIssues, [])
     const tslintReport = report(moreIssues, tslintAnnotations)
@@ -72,7 +72,7 @@ describe('Merge reports tests from Bandit and Gosec reports', () => {
     expect(result.annotations).toEqual(tslintAnnotations)
   })
 
-  test('Issues from all linters', () => {
+  test('Issues from all linters', async () => {
     const banditReport = report(someIssues, banditAnnotations)
     const gosecReport = report(moreIssues, gosecAnnotations)
     const tslintReport = report(someIssues, tslintAnnotations)

--- a/test/tslint.report.test.js
+++ b/test/tslint.report.test.js
@@ -12,7 +12,7 @@ describe('TSLint report generation', () => {
     report = generateReport(tslintResults, 'test/fixtures/js-ts')
   })
 
-  test('Creates correct report structure', () => {
+  test('Creates correct report structure', async () => {
     expect(report).toHaveProperty('annotations')
     expect(report).toHaveProperty('issueCount.errors')
     expect(report).toHaveProperty('issueCount.warnings')
@@ -20,7 +20,7 @@ describe('TSLint report generation', () => {
     expect(report).toHaveProperty('moreInfo')
   })
 
-  test('Creates correct annotations', () => {
+  test('Creates correct annotations', async () => {
     expect(report.annotations).toHaveLength(7)
     expect(report.annotations[0].end_line).toBe(56)
     expect(report.annotations[3].start_line).toBe(5)
@@ -33,7 +33,7 @@ describe('TSLint report generation', () => {
     })
   })
 
-  test('Creates correct issue count', () => {
+  test('Creates correct issue count', async () => {
     expect(report.issueCount.errors).toBe(0)
     expect(report.issueCount.warnings).toBe(7)
     expect(report.issueCount.notices).toBe(0)


### PR DESCRIPTION
The idea of the unit tests is to be independent of the order they will
be executed. That's why it makes sense to make them asynchronous and
thus make the execution of the tests faster.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>