### PR TITLE
Remove spurious handling of CheckSuiteEvent's requested action

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,16 +18,7 @@ module.exports = app => {
     const headSha = checkSuite.head_sha
     const pullRequests = checkSuite.pull_requests
 
-    if (action === 'requested') {
-      // Check suite is requested when code is pushed to the repository
-      // TODO: investigate GitHub editor not triggering check suite
-      if (pullRequests.length > 0) {
-        // Commit was pushed to a PR branch
-        return runLinterFromPRData(pullRequests, context, headSha)
-      }
-
-      // Ignore push events not linked to a pull request
-    } else if (action === 'rerequested') {
+    if (action === 'rerequested') {
       // Check suite was manually rerequested by a user on the checks dashboard
       // (previous run didn't complete)
       return runLinterFromPRData(pullRequests, context, headSha)


### PR DESCRIPTION
We don't need to respond to CheckSuiteEvent when the action is requested.
We are already listening to the events:
- pull_request: opened/reopened/synchronize
- check_run/check_suite rerequest
which are enough for us to do our work.

Our event handling covers the following scenarios:

- pull request from forked repo to the original repo
- pull request from repo to itself
- when clicked re-run-all-checks/re-run buttons on the UI on already
opened pull request

Fixes: #169 

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>