### PR TITLE
Reorder steps and tweaks in manual deployment

### DIFF
--- a/docs/manual_deployment.md
+++ b/docs/manual_deployment.md
@@ -16,14 +16,17 @@ This requires two distinct steps: setting up the environment and dependencies, a
 
 ### Go and Gosec
 
-1. Install Go if you haven't already: https://golang.org/doc/install 
-2. Download the latest version of gosec:
-```go get github.com/securego/gosec```
-3. Add $GOPATH/bin into your PATH:
+1. Install Go if you haven't already: https://golang.org/doc/install
+2. Add $GOPATH/bin into your PATH:
 ```export PATH=$PATH:${GOPATH}/bin```
-4. Add the work folder to your gopath:
+3. Add the work folder to your GOPATH:
 ```export GOPATH=$GOPATH:$(pwd)/cache/go```
+4. Download the latest version of gosec:
 
+```
+curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $GOPATH/bin 1.3.0
+```
+binary will be $GOPATH/bin/gosec
 ## Register the app
 
 Please refer to the [GitHub app documentation](https://developer.github.com/apps/building-your-first-github-app/#one-time-setup) to get started on registering your own running instance of the app.


### PR DESCRIPTION
Steps 3 and 4 from the "Setting up a manual deployment"
doc should be done before step 2.
Using the current order doesn't work because the GOPATH is needed
in order to install Gosec.

Another problem is that we are downloading Gosec with "go get".
That means that we are downloading the latest commit from the
master branch which can be unstable.
It's a lot better to download a specific version.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>