### PR TITLE
Add pip install step in manual deployment doc

### DIFF
--- a/docs/manual_deployment.md
+++ b/docs/manual_deployment.md
@@ -11,8 +11,9 @@ This requires two distinct steps: setting up the environment and dependencies, a
 
 ### Python and Bandit
 
-1. Make sure Python is installed 
-2. Run ```pip install -r requirements.txt```
+1. Make sure Python2/Python3 is installed.
+2. Make sure that pip/pip3 is installed.
+3. Run ```pip install -r requirements.txt``` or ```pip3 install -r requirements.txt``` respectively
 
 ### Go and Gosec
 


### PR DESCRIPTION
Pip is required before installing Bandit through
requirements.txt and we should document that.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>