### PR TITLE
Remove redundant async keyword

### DIFF
--- a/github_api_helper.js
+++ b/github_api_helper.js
@@ -33,7 +33,7 @@ function inProgressAPIresponse (context, headSha) {
  */
 function filterData (rawData) {
   return rawData.data.filter(file => config.fileExtensions.reduce((acc, ext) => acc || file.filename.endsWith(ext), false))
-    .filter(fileJSON => fileJSON.status !== 'removed').map(async fileInfo => {
+    .filter(fileJSON => fileJSON.status !== 'removed').map(fileInfo => {
       return fileInfo.filename
     })
 }

--- a/index.js
+++ b/index.js
@@ -96,13 +96,13 @@ async function processPullRequest (pullRequest, context) {
   const response = await apiHelper.getPRFiles(context, number)
   const filesDownloadedPromise = response
     .map(async filename => {
-      const headRevision = apiHelper.getContents(context, filename, ref, pullRequest.head)
+      const headRevision = await apiHelper.getContents(context, filename, ref, pullRequest.head)
 
       // TODO: merge this code with linter-specific path resolution
       if (filename.endsWith('.go')) {
-        cache.saveFile(repoID, id, filename, (await headRevision).data, 'go')
+        cache.saveFile(repoID, id, filename, headRevision.data, 'go')
       } else {
-        cache.saveFile(repoID, id, filename, (await headRevision).data)
+        cache.saveFile(repoID, id, filename, headRevision.data)
       }
 
       return filename

--- a/test/annotation.levels.test.js
+++ b/test/annotation.levels.test.js
@@ -5,51 +5,51 @@ const { annotationsLevels } = require('../config')
 const { getAnnotationLevel } = require('../annotations_levels')
 
 describe('Tests for annotation levels on issues with HIGH severity', () => {
-  test('HIGH severity and HIGH confidence', async () => {
+  test('HIGH severity and HIGH confidence', () => {
     const trueAnnotationLevel = getAnnotationLevel('HIGH', 'HIGH')
     expect(trueAnnotationLevel).toEqual(annotationsLevels.severityHIGHconfidenceHIGH)
   })
 
-  test('HIGH severity and MEDIUM confidence', async () => {
+  test('HIGH severity and MEDIUM confidence', () => {
     const trueAnnotationLevel = getAnnotationLevel('HIGH', 'MEDIUM')
     expect(trueAnnotationLevel).toEqual(annotationsLevels.severityHIGHconfidenceMEDIUM)
   })
 
-  test('HIGH severity and LOW confidence', async () => {
+  test('HIGH severity and LOW confidence', () => {
     const trueAnnotationLevel = getAnnotationLevel('HIGH', 'LOW')
     expect(trueAnnotationLevel).toEqual(annotationsLevels.severityHIGHconfidenceLOW)
   })
 })
 
 describe('Tests for annotation levels on issues with MEDIUM severity', () => {
-  test('MEDIUM severity and HIGH confidence', async () => {
+  test('MEDIUM severity and HIGH confidence', () => {
     const trueAnnotationLevel = getAnnotationLevel('MEDIUM', 'HIGH')
     expect(trueAnnotationLevel).toEqual(annotationsLevels.severityMEDIUMconfidenceHIGH)
   })
 
-  test('MEDIUM severity and MEDIUM confidence', async () => {
+  test('MEDIUM severity and MEDIUM confidence', () => {
     const trueAnnotationLevel = getAnnotationLevel('MEDIUM', 'MEDIUM')
     expect(trueAnnotationLevel).toEqual(annotationsLevels.severityMEDIUMconfidenceMEDIUM)
   })
 
-  test('MEDIUM severity and LOW confidence', async () => {
+  test('MEDIUM severity and LOW confidence', () => {
     const trueAnnotationLevel = getAnnotationLevel('MEDIUM', 'LOW')
     expect(trueAnnotationLevel).toEqual(annotationsLevels.severityMEDIUMconfidenceLOW)
   })
 })
 
 describe('Tests for annotation levels on issues with LOW severity', () => {
-  test('LOW severity and HIGH confidence', async () => {
+  test('LOW severity and HIGH confidence', () => {
     const trueAnnotationLevel = getAnnotationLevel('LOW', 'HIGH')
     expect(trueAnnotationLevel).toEqual(annotationsLevels.severityLOWconfidenceHIGH)
   })
 
-  test('LOW severity and MEDIUM confidence', async () => {
+  test('LOW severity and MEDIUM confidence', () => {
     const trueAnnotationLevel = getAnnotationLevel('LOW', 'MEDIUM')
     expect(trueAnnotationLevel).toEqual(annotationsLevels.severityLOWconfidenceMEDIUM)
   })
 
-  test('LOW severity and LOW confidence', async () => {
+  test('LOW severity and LOW confidence', () => {
     const trueAnnotationLevel = getAnnotationLevel('LOW', 'LOW')
     expect(trueAnnotationLevel).toEqual(annotationsLevels.severityLOWconfidenceLOW)
   })

--- a/test/bandit.report.test.js
+++ b/test/bandit.report.test.js
@@ -20,7 +20,7 @@ describe('Bandit report generation', () => {
     expect(report).toHaveProperty('moreInfo')
   })
 
-  test('Creates correct annotations', async () => {
+  test('Creates correct annotations', () => {
     expect(report.annotations).toHaveLength(4)
     expect(report.annotations[0].end_line).toBe(8)
     expect(report.annotations[3].start_line).toBe(15)
@@ -33,13 +33,13 @@ describe('Bandit report generation', () => {
     })
   })
 
-  test('Creates correct issue count', async () => {
+  test('Creates correct issue count', () => {
     expect(report.issueCount.errors).toBe(1)
     expect(report.issueCount.warnings).toBe(3)
     expect(report.issueCount.notices).toBe(0)
   })
 
-  test('Handles no vulnerable reports', async () => {
+  test('Handles no vulnerable reports', () => {
     const jsonResults = require('./fixtures/reports/bandit_safe.json')
 
     const report = generateReport(jsonResults)

--- a/test/check.run.conclusion.test.js
+++ b/test/check.run.conclusion.test.js
@@ -4,29 +4,29 @@
 const { getConclusion } = require('../github_api_helper')
 
 describe('Check run conclusions tests', () => {
-  test('Empty annotations', async () => {
+  test('Empty annotations', () => {
     const trueConclusion = getConclusion([])
     expect(trueConclusion).toEqual('success')
   })
 
-  test('Undefined annotations', async () => {
+  test('Undefined annotations', () => {
     const trueConclusion = getConclusion('undefined')
     expect(trueConclusion).toEqual('success')
   })
 
-  test('Mixed annotation levels', async () => {
+  test('Mixed annotation levels', () => {
     const { annotations } = require('./fixtures/annotations/mixed_levels_annotations.json')
     const trueConclusion = getConclusion(annotations)
     expect(trueConclusion).toEqual('failure')
   })
 
-  test('Warning and neutral annotations', async () => {
+  test('Warning and neutral annotations', () => {
     const { annotations } = require('./fixtures/annotations/warning_neutral_annotations.json')
     const trueConclusion = getConclusion(annotations)
     expect(trueConclusion).toEqual('neutral')
   })
 
-  test('Neutral annotations', async () => {
+  test('Neutral annotations', () => {
     const { annotations } = require('./fixtures/annotations/neutral_annotations.json')
     const trueConclusion = getConclusion(annotations)
     expect(trueConclusion).toEqual('success')

--- a/test/gosec.report.test.js
+++ b/test/gosec.report.test.js
@@ -12,7 +12,7 @@ describe('Gosec report generation', () => {
     report = generateReport(gosecResults, 'test/fixtures/go/src')
   })
 
-  test('Creates correct report structure', async () => {
+  test('Creates correct report structure', () => {
     expect(report).toHaveProperty('annotations')
     expect(report).toHaveProperty('issueCount.errors')
     expect(report).toHaveProperty('issueCount.warnings')
@@ -20,7 +20,7 @@ describe('Gosec report generation', () => {
     expect(report).toHaveProperty('moreInfo')
   })
 
-  test('Creates correct annotations', async () => {
+  test('Creates correct annotations', () => {
     expect(report.annotations).toHaveLength(6)
     expect(report.annotations[0].end_line).toBe(16)
     expect(report.annotations[3].start_line).toBe(28)
@@ -33,13 +33,13 @@ describe('Gosec report generation', () => {
     })
   })
 
-  test('Creates correct issue count', async () => {
+  test('Creates correct issue count', () => {
     expect(report.issueCount.errors).toBe(1)
     expect(report.issueCount.warnings).toBe(5)
     expect(report.issueCount.notices).toBe(0)
   })
 
-  test('Handles no vulnerable reports', async () => {
+  test('Handles no vulnerable reports', () => {
     const jsonResults = require('./fixtures/reports/gosec_safe.json')
 
     const report = generateReport(jsonResults)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -253,7 +253,7 @@ describe('Precaution workflow', () => {
       }))
     })
 
-    test('send many annotations through multiple API calls', async () => {
+    test('send many annotations through multiple API calls', () => {
       const { sendResults } = require('../github_api_helper')
       let context = {
         github: {

--- a/test/merge.reports.test.js
+++ b/test/merge.reports.test.js
@@ -17,7 +17,7 @@ const report = (issueCount, annotations) => {
 }
 
 describe('Merge reports tests from Bandit and Gosec reports', () => {
-  test('No issues', async () => {
+  test('No issues', () => {
     const banditReport = report(noIssues, [])
     const gosecReport = report(noIssues, [])
     const tslintReport = report(noIssues, [])
@@ -28,7 +28,7 @@ describe('Merge reports tests from Bandit and Gosec reports', () => {
     expect(result.annotations).toHaveLength(0)
   })
 
-  test('Bandit issues', async () => {
+  test('Bandit issues', () => {
     // We don't need the issue count to correspond to the actual annotations (code handles them separately)
     const banditReport = report(someIssues, banditAnnotations)
     const gosecReport = report(noIssues, [])
@@ -44,7 +44,7 @@ describe('Merge reports tests from Bandit and Gosec reports', () => {
     expect(result.annotations).toEqual(banditAnnotations)
   })
 
-  test('Gosec issues', async () => {
+  test('Gosec issues', () => {
     const banditReport = report(noIssues, [])
     const gosecReport = report(moreIssues, gosecAnnotations)
     const tslintReport = report(noIssues, [])
@@ -58,7 +58,7 @@ describe('Merge reports tests from Bandit and Gosec reports', () => {
     expect(result.annotations).toEqual(gosecAnnotations)
   })
 
-  test('TSLint issues', async () => {
+  test('TSLint issues', () => {
     const banditReport = report(noIssues, [])
     const gosecReport = report(noIssues, [])
     const tslintReport = report(moreIssues, tslintAnnotations)
@@ -72,7 +72,7 @@ describe('Merge reports tests from Bandit and Gosec reports', () => {
     expect(result.annotations).toEqual(tslintAnnotations)
   })
 
-  test('Issues from all linters', async () => {
+  test('Issues from all linters', () => {
     const banditReport = report(someIssues, banditAnnotations)
     const gosecReport = report(moreIssues, gosecAnnotations)
     const tslintReport = report(someIssues, tslintAnnotations)

--- a/test/tslint.report.test.js
+++ b/test/tslint.report.test.js
@@ -12,7 +12,7 @@ describe('TSLint report generation', () => {
     report = generateReport(tslintResults, 'test/fixtures/js-ts')
   })
 
-  test('Creates correct report structure', async () => {
+  test('Creates correct report structure', () => {
     expect(report).toHaveProperty('annotations')
     expect(report).toHaveProperty('issueCount.errors')
     expect(report).toHaveProperty('issueCount.warnings')
@@ -20,7 +20,7 @@ describe('TSLint report generation', () => {
     expect(report).toHaveProperty('moreInfo')
   })
 
-  test('Creates correct annotations', async () => {
+  test('Creates correct annotations', () => {
     expect(report.annotations).toHaveLength(7)
     expect(report.annotations[0].end_line).toBe(56)
     expect(report.annotations[3].start_line).toBe(5)
@@ -33,13 +33,13 @@ describe('TSLint report generation', () => {
     })
   })
 
-  test('Creates correct issue count', async () => {
+  test('Creates correct issue count', () => {
     expect(report.issueCount.errors).toBe(0)
     expect(report.issueCount.warnings).toBe(7)
     expect(report.issueCount.notices).toBe(0)
   })
 
-  test('Handles no vulnerable reports', async () => {
+  test('Handles no vulnerable reports', () => {
     const report = generateReport([], '')
 
     expect(report.annotations).toHaveLength(0)


### PR DESCRIPTION
Nodejs is single threaded but uses an event loop
for Asynchronous calls.
It has an async/await mechanism which should be used when we have
external service or when we need to wait for a data
(and we don't have immediate access to it).

Practically that translates to the simple idea that if we are calling
one function that is async or if it returns a Promise
then we need to await the result of that function and thus use our
own async function.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>