### PR TITLE
Document our decision to ignore tool specific configuration files

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,6 +3,17 @@
     SPDX-License-Identifier: BSD-2-Clause
 -->
 
+# Overview
+
+Precaution provides simple, automated code reviews for GitHub projects by
+running security analysis tools on all Pull Requests. Precaution achieves this
+by using a variety of tools under the hood without exposing implementation
+details and complexity of the underlying tools to the user.
+
+Concretely, this means that Precaution ignores any tool specific configuration
+files which may exist in the project's repository and performs scans based only
+on Precaution specific configuration.
+
 # Control Flow
 
 ![architecture](architecture.svg)


### PR DESCRIPTION
We are opting to ignore tool specific configuration files which may exist in
the repository and only use configuration which has been set in precaution.json

This strategy allows us to expose relevant functionality common to all
supported linters in a consistent fashion. Furthermore by not exposing tool
specific configuration via Precaution we don't have to worry about migration
paths should we choose to change the underlying tools in future.

Closes: #81

Signed-off-by: Joshua Lock <jlock@vmware.com>