### PR TITLE
The tslint plugin should filter on *.ts not *ts

### DIFF
--- a/linters/tslint.js
+++ b/linters/tslint.js
@@ -26,7 +26,7 @@ module.exports = class TSLint {
    * @returns {string[]} Filtered list of file names
    */
   filter (files) {
-    return files.filter(name => name.endsWith('.js') || name.endsWith('ts'))
+    return files.filter(name => name.endsWith('.js') || name.endsWith('.ts'))
   }
 
   /**


### PR DESCRIPTION
Trivial fix to add the dot so that the filter only matches files
with a ts extension and not any file ending in ts.

Fixes issue #224

Signed-off-by: Eric Brown <browne@vmware.com>