### PR TITLE
Change the build badge link of Travis CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ![Precaution](precaution-logo.png)
 
-[![Build Status](https://travis-ci.com/vmware/precaution.svg?branch=master)](https://travis-ci.com/vmware/precaution)
+[![Build Status](https://travis-ci.org/vmware/precaution.svg?branch=master)](https://travis-ci.org/vmware/precaution)
 [![Coverage Status](https://codecov.io/gh/vmware/precaution/branch/master/graph/badge.svg)](https://codecov.io/gh/vmware/precaution)
 [![License](https://img.shields.io/badge/License-BSD%202--Clause-orange.svg)](https://github.com/vmware/precaution/blob/master/LICENSE.txt)
 [![Slack](https://img.shields.io/badge/slack-join%20chat%20%E2%86%92-e01563.svg)](https://code.vmware.com/web/code/join)


### PR DESCRIPTION
We are using the badge for travis-ci.com instead
of travis-ci.org which we are using right now.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>