### PR TITLE
Add report functionality for detect-secrets + tests

### DIFF
--- a/linters/detect_secrets/detect_secrets_annotations.js
+++ b/linters/detect_secrets/detect_secrets_annotations.js
@@ -1,0 +1,32 @@
+// Copyright 2019 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+const pathLib = require('path')
+
+const { getAnnotationLevel } = require('../../annotations_levels')
+
+/**
+ * @param {*} issue an issue from which the annotation will be build
+ * @param {String} filePath file path where the issue is located
+ * @return {Object} returns an annotation object as specified here:
+ * https://developer.github.com/v3/checks/runs/#annotations-object
+ */
+function getAnnotation (issue, filePath) {
+  const path = pathLib.normalize(filePath)
+  const startLine = issue.line_number
+  const endLine = startLine
+  const annotationLevel = getAnnotationLevel('HIGH', 'LOW')
+  const title = issue.type
+  const message = `The issue was found by the ${issue.type} plugin in detect-secrets.`
+
+  return {
+    path,
+    start_line: startLine,
+    end_line: endLine,
+    annotation_level: annotationLevel,
+    title,
+    message
+  }
+}
+
+module.exports.getAnnotation = getAnnotation

--- a/linters/detect_secrets/detect_secrets_report.js
+++ b/linters/detect_secrets/detect_secrets_report.js
@@ -1,0 +1,29 @@
+// Copyright 2019 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+const { getAnnotation } = require('./detect_secrets_annotations')
+const { countIssueLevels } = require('../../annotations_levels')
+
+/**
+ * Process detect-secrets output (generate annotations, count issue levels)
+ * @param {*} results detect-secrets json output
+ * @returns {{{Object[]}, Object, String}} Object[] array of annotation objects
+ * see https://developer.github.com/v3/checks/runs/#annotations-object
+ * Object contains the number of errors, warnings and notices found
+ * String consists of link|links to the documentation for the issues
+ */
+module.exports = (results) => {
+  const filesWithIssues = Object.keys(results)
+  let annotations = []
+  for (let file of filesWithIssues) {
+    for (let issue of results[file]) {
+      annotations.push(getAnnotation(issue, file))
+    }
+  }
+  const issueCount = countIssueLevels(annotations)
+  let moreInfo = ''
+  if (annotations.length > 0) {
+    moreInfo = '[detect-secrets documentation](https://github.com/Yelp/detect-secrets#currently-supported-plugins)'
+  }
+  return { annotations, issueCount, moreInfo }
+}

--- a/test/detect_secrets.report.test.js
+++ b/test/detect_secrets.report.test.js
@@ -1,0 +1,50 @@
+// Copyright 2019 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+const generateReport = require('../linters/detect_secrets/detect_secrets_report')
+
+const detectSecretsResults = require('./fixtures/reports/detect_secrets.vulnerable')
+
+describe('TSLint report generation', () => {
+  let report = ''
+
+  beforeEach(() => {
+    report = generateReport(detectSecretsResults.results)
+  })
+
+  test('Creates correct report structure', () => {
+    expect(report).toHaveProperty('annotations')
+    expect(report).toHaveProperty('issueCount.errors')
+    expect(report).toHaveProperty('issueCount.warnings')
+    expect(report).toHaveProperty('issueCount.notices')
+    expect(report).toHaveProperty('moreInfo')
+  })
+
+  test('Creates correct annotations', () => {
+    expect(report.annotations).toHaveLength(4)
+    expect(report.annotations[0].end_line).toBe(13)
+    expect(report.annotations[1].start_line).toBe(68)
+    expect(report.annotations[2].title).toEqual('Basic Auth Credentials')
+    expect(report.annotations[3].path).toBe('test.yaml')
+
+    report.annotations.forEach(annotation => {
+      expect(annotation.annotation_level).toMatch(/notice|warning|failure/)
+      expect(annotation.message).not.toBe('')
+    })
+  })
+
+  test('Creates correct issue count', () => {
+    expect(report.issueCount.errors).toBe(4)
+    expect(report.issueCount.warnings).toBe(0)
+    expect(report.issueCount.notices).toBe(0)
+  })
+
+  test('Handles no vulnerable reports', () => {
+    const report = generateReport([], '')
+
+    expect(report.annotations).toHaveLength(0)
+    expect(report.issueCount.errors).toBe(0)
+    expect(report.issueCount.warnings).toBe(0)
+    expect(report.issueCount.notices).toBe(0)
+  })
+})

--- a/test/fixtures/reports/detect_secrets.vulnerable.json
+++ b/test/fixtures/reports/detect_secrets.vulnerable.json
@@ -1,0 +1,59 @@
+{
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2019-05-15T17:24:04Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    }
+  ],
+  "results": {
+    "test.js": [
+      {
+        "hashed_secret": "edbd2994e5980ce68a498791abc1fb9c40f6bb43",
+        "line_number": 13,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "daefe0b4345a654580dcad25c7c11ff4c944a8c0",
+        "line_number": 68,
+        "type": "Private Key"
+      },
+      {
+        "hashed_secret": "99b5e14eaf6b7cd863796dab48ae736be2ac6b53",
+        "line_number": 77,
+        "type": "Basic Auth Credentials"
+      }
+    ],
+    "test.yaml": [
+      {
+        "hashed_secret": "66e02bb499b2a3f5f2894ce1b7959962c1a5a245",
+        "line_number": 5,
+        "type": "Base64 High Entropy String"
+      }
+    ]
+  },
+  "version": "0.12.2"
+}


### PR DESCRIPTION
This is the reporting functionality for detect_secrets which will
process the results from the detect_secrets detect_secrets scan
and it will create valid GitHub annotation objects for the issues.

All upcoming pull requests to integrate detect_secrets
into Precaution can be found here:
https://github.com/vmware/precaution/issues/209#issuecomment-492964642

Related to: https://github.com/vmware/precaution/issues/209

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>