### PR TITLE
Fix filename extensions in config.fileExtensions to have preceding '.'

### DIFF
--- a/config.js
+++ b/config.js
@@ -3,7 +3,7 @@
 
 const config = {
   cleanupAfterRun: true,
-  fileExtensions: ['.py', '.pyw', '.go', 'js', 'ts'],
+  fileExtensions: ['.py', '.pyw', '.go', '.js', '.ts'],
   checkRunName: 'Precaution',
   noIssuesResultTitle: 'No issues found',
   noIssuesResultSummary: 'There were no issues found.',


### PR DESCRIPTION
Some of file extensions were listed in the fileExtensions array with a
preceding '.' and others were not. We must be consistent in using the '.'
prefix to all file extensions in the array, otherwise we may have unexpected
behaviours such as the filterData() function in github_api_helper.js
matching all filenames that end with 'js' or 'ts'.

Signed-off-by: Joshua Lock <jlock@vmware.com>