### PR TITLE
Add Gif to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 Precaution provides simple, automated code reviews for GitHub projects by running
 code linters with a security focus on all pull requests.
 
+![Precaution Demo](./precaution.gif)
+
 GitHub integration is made through the GitHub app interface and the checks API (beta),
 which allows results to be presented directly as inline annotations instead of
 a pass/fail status report.


### PR DESCRIPTION
It will be really useful if we add a GIF to the Precaution README.
That way we would show how Precaution works in 17 seconds!

Closes: https://github.com/vmware/precaution/issues/106

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>