### PR TITLE
Make "Redirect Github webhooks" step mandatory

### DIFF
--- a/docs/manual_deployment.md
+++ b/docs/manual_deployment.md
@@ -58,10 +58,11 @@ Additionnally the app should subscribe to the **Pull requests** event.
 
 ## Redirect Github webhooks to your local machine
 
-This can be useful when you are doing development work on Precaution itself and need a simple solution to trace the webhooks sent by GitHub and receive them without exposing your app to the internet.
+This step is required when debugging the Precaution workflow and its interaction with GitHub.
+Without it you won't be able to see the Precaution results on GitHub.
 
 Please refer to the [Probot documentation](https://probot.github.io/docs/development/#configuring-a-github-app)
-to direct GitHub webhooks to your local machine.
+to direct the GitHub webhooks to your local machine.
 
 ## Testing
 


### PR DESCRIPTION
In our doc "Setting up a manual deployment" we didn't emphasize
how important it is to redirect the GitHub webhooks to your local
machine.
Without this step you can't see how Precaution actually works!

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>